### PR TITLE
feat : 메인홈 조회 API 구현 및 swagger작성

### DIFF
--- a/src/main/java/org/farm/fireflyserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/farm/fireflyserver/common/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
             "/senior/**",
             "/led/save",
             "/account/login",
-
+            "/monitoring/**"
 
             };
 

--- a/src/main/java/org/farm/fireflyserver/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/farm/fireflyserver/common/exception/handler/GlobalExceptionHandler.java
@@ -13,10 +13,21 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+    /**
+     * 잘못된 URL 요청 시 발생하는 error를 handling합니다.
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<BaseResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error(">>> handle: NoResourceFoundException ", e);
+        final BaseResponse errorBaseResponse = BaseResponse.of(ErrorCode.RESOURCE_NOT_FOUND);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorBaseResponse);
+    }
+
     /**
      * Valid & Validated annotation의 binding error를 handling합니다.
      */

--- a/src/main/java/org/farm/fireflyserver/common/util/HealthCheckController.java
+++ b/src/main/java/org/farm/fireflyserver/common/util/HealthCheckController.java
@@ -1,11 +1,13 @@
 package org.farm.fireflyserver.common.util;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "서버 HealthCheck", description = "Health Check API")
 public class HealthCheckController {
 
     @GetMapping

--- a/src/main/java/org/farm/fireflyserver/common/util/TempTokenController.java
+++ b/src/main/java/org/farm/fireflyserver/common/util/TempTokenController.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.common.util;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.config.jwt.JwtProvider;
 import org.farm.fireflyserver.common.response.BaseResponse;
@@ -9,10 +11,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
+@Tag(name = "임시 토큰 발급", description = "임시 토큰 발급 API")
 public class TempTokenController {
 
     private final JwtProvider jwtProvider;
 
+    @Operation(summary = "임시 토큰 발급")
     @PostMapping("/token/{id}")
     BaseResponse<String> getTempToken(@PathVariable Long id) {
         String token = jwtProvider.getIssueToken(id, true);

--- a/src/main/java/org/farm/fireflyserver/domain/account/web/AccountController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/account/web/AccountController.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.domain.account.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/account")
 @RequiredArgsConstructor
+@Tag(name = "Account", description = "계정 관련 API")
 public class AccountController {
 
     private final AccountService accountService;
 
+    @Operation(summary = "로그인", description = "사용자 로그인 API(예시 값으로 테스트 가능)")
     @PostMapping("/login")
     public BaseResponse<?> login(@RequestBody LoginDto loginDto) {
         TokenDto token = accountService.login(loginDto);

--- a/src/main/java/org/farm/fireflyserver/domain/account/web/dto/LoginDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/account/web/dto/LoginDto.java
@@ -1,8 +1,11 @@
 package org.farm.fireflyserver.domain.account.web.dto;
 
-public record LoginDto(
-    String id,
-    String password
+import io.swagger.v3.oas.annotations.media.Schema;
 
+public record LoginDto(
+        @Schema(example = "manager_kim")
+        String id,
+        @Schema(example = "password123")
+        String password
 ) {
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/Type.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/Type.java
@@ -1,15 +1,21 @@
 package org.farm.fireflyserver.domain.care;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.exception.InvalidValueException;
 import org.farm.fireflyserver.common.response.ErrorCode;
 
 import java.util.stream.Stream;
 
+@RequiredArgsConstructor
+@Getter
 public enum Type {
-    CALL,
-    VISIT,
-    EMERGENCY;
+    CALL("전화돌봄"),
+    VISIT("방문돌봄"),
+    EMERGENCY("긴급출동");
+
+    private final String desc;
 
     @JsonCreator
     public static Type from(String type) {

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CareRepository extends JpaRepository<Care, Long> {
@@ -31,4 +32,6 @@ public interface CareRepository extends JpaRepository<Care, Long> {
             "m.name LIKE %:#{#req.searchTerm}% OR " +
             "m.phoneNum LIKE %:#{#req.searchTerm}%)")
     List<Care> search(@Param("req") CareDto.SearchRequest dto);
+
+    List<Care> findAllByDateBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedHistory.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedHistory.java
@@ -1,16 +1,16 @@
 package org.farm.fireflyserver.domain.led.persistence.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
 
-@Getter(AccessLevel.PROTECTED)
+@Getter
 @NoArgsConstructor
 @Entity
+@Builder
+@AllArgsConstructor
 @Table(name = "led_history")
 public class LedHistory {
 
@@ -26,5 +26,5 @@ public class LedHistory {
     private SensorGbn sensorGbn;
 
     @Comment("LED 점등 시각")
-    private LocalDateTime OnDate;
+    private LocalDateTime onDate;
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedState.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedState.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.farm.fireflyserver.common.util.BaseUpdatedTimeEntity;
+import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.hibernate.annotations.Comment;
 
 @Entity
@@ -23,6 +24,11 @@ public class LedState extends BaseUpdatedTimeEntity {
     @Enumerated(EnumType.STRING)
     @Comment("LED 센서 구분")
     private SensorGbn sensorGbn;
+
+    @ManyToOne
+    @JoinColumn(name = "senior_id", nullable = false)
+    @Comment("대상자 식별 정보")
+    private Senior senior;
 
 
 

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/SensorGbn.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/SensorGbn.java
@@ -15,6 +15,14 @@ public enum SensorGbn {
     private final String code;
     private final String desc;
 
-    //코드로 저장시 Convert 필요
+    //code->enum
+    public static SensorGbn fromCode(String code) {
+        for (SensorGbn sensorGbn : SensorGbn.values()) {
+            if (sensorGbn.getCode().equals(code)) {
+                return sensorGbn;
+            }
+        }
+        throw new IllegalArgumentException();
+    }
 
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
@@ -1,0 +1,7 @@
+package org.farm.fireflyserver.domain.led.persistence.repository;
+
+import org.farm.fireflyserver.domain.led.persistence.entity.LedHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LedHistoryRepository extends JpaRepository<LedHistory, Long> {
+}

--- a/src/main/java/org/farm/fireflyserver/domain/led/web/controller/LedController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/web/controller/LedController.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.domain.led.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -13,12 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/led")
+@Tag(name = "Led", description = "LED 관련 API")
 public class LedController {
 
     private final LedService ledService;
 
     //임시로 토큰 없이 저장
-    @PostMapping("/save")
+    @Operation(summary = "LED 데이터 저장(구현 X)")
+            @PostMapping("/save")
     BaseResponse<?> saveLedData(@RequestBody SaveLedDataDto dto){
         ledService.saveLedData(dto);
         return BaseResponse.of(SuccessCode.CREATED, null);

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringService.java
@@ -1,0 +1,7 @@
+package org.farm.fireflyserver.domain.monitoring.service;
+
+import org.farm.fireflyserver.domain.monitoring.web.dto.MainHomeDto;
+
+public interface MonitoringService {
+    MainHomeDto getMainHome();
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
@@ -1,11 +1,15 @@
 package org.farm.fireflyserver.domain.monitoring.service;
 
 import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.domain.care.persistence.CareRepository;
+import org.farm.fireflyserver.domain.care.persistence.entity.Care;
 import org.farm.fireflyserver.domain.monitoring.web.dto.*;
 import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
@@ -14,24 +18,26 @@ import java.util.List;
 public class MonitoringServiceImpl implements MonitoringService {
 
     private final SeniorRepository seniorRepository;
+    private final CareRepository careRepository;
 
     @Override
     public MainHomeDto getMainHome() {
         SeniorCountDto seniorCount = getSeniorCount();
         SeniorLedStateCountDto seniorStateCount = getSeniorStateCount();
-        return MainHomeDto.of(seniorCount, seniorStateCount);
+        MonthlyCareStateDto monthlyCareState = getMonthlyCareState();
+        return MainHomeDto.of(seniorCount, seniorStateCount,monthlyCareState);
 
     }
 
     // 대상자 수 조회
     private SeniorCountDto getSeniorCount() {
-        int totalHouseCount = seniorRepository.countByIsActiveTrue();
+        int totalCount = seniorRepository.countByIsActiveTrue();
         int amiUseCount = seniorRepository.countByIsActiveTrueAndIsAmiUseTrue();
         int ledUseCount = seniorRepository.countByIsActiveTrueAndIsLedUseTrue();
 
         List<ByTownCountDto> byTownCount = getSeniorCountByTown();
 
-        return SeniorCountDto.of(totalHouseCount, ledUseCount, amiUseCount, byTownCount);
+        return SeniorCountDto.of(totalCount, ledUseCount, amiUseCount, byTownCount);
     }
 
     // 읍면동별로 대상자 수
@@ -61,10 +67,7 @@ public class MonitoringServiceImpl implements MonitoringService {
     }
 
     private int[] calculateStateCounts(List<Object[]> results) {
-        int normalCount = 0;
-        int interestCount = 0;
-        int cautionCount = 0;
-        int dangerCount = 0;
+        int normalCount = 0, interestCount = 0, cautionCount = 0, dangerCount = 0;
 
         for (Object[] row : results) {
             String dangerLevel = (String) row[0];
@@ -95,6 +98,42 @@ public class MonitoringServiceImpl implements MonitoringService {
                                 .orElse(null)
                 ))
                 .toList();
+    }
+
+    // 월별 돌봄 현황
+    public MonthlyCareStateDto getMonthlyCareState() {
+        int year = LocalDate.now().getYear();
+        int month = LocalDate.now().getMonthValue();
+
+        List<Care> cares = getCaresByMonth(year, month);
+
+        int totalCount = seniorRepository.countByIsActiveTrue();
+        int callCount = 0, visitCount = 0, emergencyCount = 0;
+
+        for (Care care : cares) {
+            switch (care.getType()) {
+                case CALL -> callCount++;
+                case VISIT -> visitCount++;
+                case EMERGENCY -> emergencyCount++;
+            }
+        }
+
+        int careCount = callCount + visitCount + emergencyCount;
+        String monthStr = String.format("%04d.%02d", year, month);
+
+        return MonthlyCareStateDto.of(monthStr, totalCount, careCount, callCount, visitCount, emergencyCount);
+    }
+
+    // 월별 돌봄 기록 조회
+    private List<Care> getCaresByMonth(int year, int month) {
+        YearMonth targetMonth = YearMonth.of(year, month);
+        LocalDate startDate = targetMonth.atDay(1);
+        LocalDate endDate = targetMonth.atEndOfMonth();
+
+        return careRepository.findAllByDateBetween(
+                startDate.atStartOfDay(),
+                endDate.atTime(23, 59, 59)
+        );
     }
 
 }

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
@@ -1,9 +1,7 @@
 package org.farm.fireflyserver.domain.monitoring.service;
 
 import lombok.RequiredArgsConstructor;
-import org.farm.fireflyserver.domain.monitoring.web.dto.ByTownCountDto;
-import org.farm.fireflyserver.domain.monitoring.web.dto.MainHomeDto;
-import org.farm.fireflyserver.domain.monitoring.web.dto.SeniorCountDto;
+import org.farm.fireflyserver.domain.monitoring.web.dto.*;
 import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,21 +11,22 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class MonitoringServiceImpl  implements MonitoringService {
+public class MonitoringServiceImpl implements MonitoringService {
 
     private final SeniorRepository seniorRepository;
 
     @Override
     public MainHomeDto getMainHome() {
         SeniorCountDto seniorCount = getSeniorCount();
-        return MainHomeDto.of(seniorCount);
+        SeniorLedStateCountDto seniorStateCount = getSeniorStateCount();
+        return MainHomeDto.of(seniorCount, seniorStateCount);
 
     }
 
     // 대상자 수 조회
     private SeniorCountDto getSeniorCount() {
         int totalHouseCount = seniorRepository.countByIsActiveTrue();
-        int amiUseCount =  seniorRepository.countByIsActiveTrueAndIsAmiUseTrue();
+        int amiUseCount = seniorRepository.countByIsActiveTrueAndIsAmiUseTrue();
         int ledUseCount = seniorRepository.countByIsActiveTrueAndIsLedUseTrue();
 
         List<ByTownCountDto> byTownCount = getSeniorCountByTown();
@@ -46,4 +45,56 @@ public class MonitoringServiceImpl  implements MonitoringService {
                 ))
                 .toList();
     }
+
+    // Led 이상 탐지 현황
+    private SeniorLedStateCountDto getSeniorStateCount() {
+        List<Object[]> results = seniorRepository.countByDangerLevel();
+        int ledUseCount = seniorRepository.countByIsActiveTrueAndIsLedUseTrue();
+
+        //이상 탐지 통계
+        int[] counts = calculateStateCounts(results);
+
+        // 대상자별 상태 정보
+        List<SeniorLedStateDto> seniorLedStates = convertToLedStateDto();
+
+        return SeniorLedStateCountDto.of(ledUseCount, counts[0], counts[1], counts[2], counts[3], seniorLedStates);
+    }
+
+    private int[] calculateStateCounts(List<Object[]> results) {
+        int normalCount = 0;
+        int interestCount = 0;
+        int cautionCount = 0;
+        int dangerCount = 0;
+
+        for (Object[] row : results) {
+            String dangerLevel = (String) row[0];
+            int count = ((Long) row[1]).intValue();
+
+            //enum으로 수정 필요
+            if (dangerLevel == null || dangerLevel.equals("정상")) {
+                normalCount = count;
+            } else if (dangerLevel.equals("관심")) {
+                interestCount = count;
+            } else if (dangerLevel.equals("위험")) {
+                dangerCount = count;
+            } else if (dangerLevel.equals("주의")) {
+                cautionCount = count;
+            }
+        }
+
+        return new int[]{normalCount, interestCount, cautionCount, dangerCount};
+    }
+
+    private List<SeniorLedStateDto> convertToLedStateDto() {
+        return seniorRepository.findByIsActiveTrueAndIsLedUseTrue().stream()
+                .map(senior -> SeniorLedStateDto.from(
+                        senior,
+                        senior.getCareList().stream()
+                                .map(care -> care.getManagerAccount().getName())
+                                .findFirst()
+                                .orElse(null)
+                ))
+                .toList();
+    }
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
@@ -1,0 +1,49 @@
+package org.farm.fireflyserver.domain.monitoring.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.domain.monitoring.web.dto.ByTownCountDto;
+import org.farm.fireflyserver.domain.monitoring.web.dto.MainHomeDto;
+import org.farm.fireflyserver.domain.monitoring.web.dto.SeniorCountDto;
+import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MonitoringServiceImpl  implements MonitoringService {
+
+    private final SeniorRepository seniorRepository;
+
+    @Override
+    public MainHomeDto getMainHome() {
+        SeniorCountDto seniorCount = getSeniorCount();
+        return MainHomeDto.of(seniorCount);
+
+    }
+
+    // 대상자 수 조회
+    private SeniorCountDto getSeniorCount() {
+        int totalHouseCount = seniorRepository.countByIsActiveTrue();
+        int amiUseCount =  seniorRepository.countByIsActiveTrueAndIsAmiUseTrue();
+        int ledUseCount = seniorRepository.countByIsActiveTrueAndIsLedUseTrue();
+
+        List<ByTownCountDto> byTownCount = getSeniorCountByTown();
+
+        return SeniorCountDto.of(totalHouseCount, ledUseCount, amiUseCount, byTownCount);
+    }
+
+    // 읍면동별로 대상자 수
+    private List<ByTownCountDto> getSeniorCountByTown() {
+        List<Object[]> results = seniorRepository.countByTown();
+
+        return results.stream()
+                .map(row -> ByTownCountDto.of(
+                        (String) row[0],
+                        ((Long) row[1]).intValue()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/MonitoringController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/MonitoringController.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.domain.monitoring.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -12,11 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/monitoring")
+@Tag(name = "Monitoring", description = "모니터링/대시보드 관련 API")
 public class MonitoringController {
 
     private final MonitoringService monitoringService;
 
     @GetMapping("/main")
+    @Operation(summary = "메인 홈 모니터링 정보 조회",
+            description = "메인 홈 모니터링 정보 조회(레이아웃별로 구성된 정보 반환) + \n"+
+                    "지역별 대상자 상태 현황은 필터링 아직 적용 전이라 지역별 대상자 상태 현황을 한 번에 반환합니다!(이후 적용 예정)")
     public BaseResponse<?> getMainHome(){
         MainHomeDto mainHome = monitoringService.getMainHome();
         return BaseResponse.of(SuccessCode.OK, mainHome);

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/MonitoringController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/MonitoringController.java
@@ -1,0 +1,24 @@
+package org.farm.fireflyserver.domain.monitoring.web;
+
+import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.common.response.BaseResponse;
+import org.farm.fireflyserver.common.response.SuccessCode;
+import org.farm.fireflyserver.domain.monitoring.service.MonitoringService;
+import org.farm.fireflyserver.domain.monitoring.web.dto.MainHomeDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/monitoring")
+public class MonitoringController {
+
+    private final MonitoringService monitoringService;
+
+    @GetMapping("/main")
+    public BaseResponse<?> getMainHome(){
+        MainHomeDto mainHome = monitoringService.getMainHome();
+        return BaseResponse.of(SuccessCode.OK, mainHome);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/ByTownCountDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/ByTownCountDto.java
@@ -1,0 +1,10 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+public record ByTownCountDto(
+        String townName,
+        int totalCountbyTown
+) {
+    public static ByTownCountDto of(String townName, int totalCountbyTown) {
+        return new ByTownCountDto(townName, totalCountbyTown);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
@@ -1,12 +1,15 @@
 package org.farm.fireflyserver.domain.monitoring.web.dto;
 
+import java.util.List;
+
 public record MainHomeDto(
     SeniorCountDto seniorCount,
     SeniorLedStateCountDto seniorStateCount,
-    MonthlyCareStateDto monthlyCareState
+    MonthlyCareStateDto monthlyCareState,
+    List<TownStateDto> townState
 ) {
-    public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount,    MonthlyCareStateDto monthlyCareState) {
+    public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount, MonthlyCareStateDto monthlyCareState, List<TownStateDto> townState) {
 
-        return new MainHomeDto(seniorCount,seniorStateCount,monthlyCareState);
+        return new MainHomeDto(seniorCount,seniorStateCount,monthlyCareState,townState);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
@@ -2,10 +2,11 @@ package org.farm.fireflyserver.domain.monitoring.web.dto;
 
 public record MainHomeDto(
     SeniorCountDto seniorCount,
-    SeniorLedStateCountDto seniorStateCount
+    SeniorLedStateCountDto seniorStateCount,
+    MonthlyCareStateDto monthlyCareState
 ) {
-    public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount) {
+    public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount,    MonthlyCareStateDto monthlyCareState) {
 
-        return new MainHomeDto(seniorCount,seniorStateCount);
+        return new MainHomeDto(seniorCount,seniorStateCount,monthlyCareState);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
@@ -1,12 +1,21 @@
 package org.farm.fireflyserver.domain.monitoring.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MainHomeDto(
-    SeniorCountDto seniorCount,
-    SeniorLedStateCountDto seniorStateCount,
-    MonthlyCareStateDto monthlyCareState,
-    List<TownStateDto> townState
+        @Schema(description = "서비스 대상자 현황")
+        SeniorCountDto seniorCount,
+
+        @Schema(description = "LED 이상 탐지 현황")
+        SeniorLedStateCountDto seniorStateCount,
+
+        @Schema(description = "월간 돌봄 현황")
+        MonthlyCareStateDto monthlyCareState,
+
+        @Schema(description = "지역별 대상자 상태 현황")
+        List<TownStateDto> townState
 ) {
     public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount, MonthlyCareStateDto monthlyCareState, List<TownStateDto> townState) {
 

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
@@ -1,9 +1,11 @@
 package org.farm.fireflyserver.domain.monitoring.web.dto;
 
 public record MainHomeDto(
-    SeniorCountDto seniorCount
+    SeniorCountDto seniorCount,
+    SeniorLedStateCountDto seniorStateCount
 ) {
-    public static MainHomeDto of(SeniorCountDto seniorCount) {
-        return new MainHomeDto(seniorCount);
+    public static MainHomeDto of(SeniorCountDto seniorCount, SeniorLedStateCountDto seniorStateCount) {
+
+        return new MainHomeDto(seniorCount,seniorStateCount);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MainHomeDto.java
@@ -1,0 +1,9 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+public record MainHomeDto(
+    SeniorCountDto seniorCount
+) {
+    public static MainHomeDto of(SeniorCountDto seniorCount) {
+        return new MainHomeDto(seniorCount);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MonthlyCareStateDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/MonthlyCareStateDto.java
@@ -1,0 +1,14 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+public record MonthlyCareStateDto(
+        String month,
+        int totalCount,
+        int careCount,
+        int callCount,
+        int visitCount,
+        int emergencyCount
+) {
+    public static MonthlyCareStateDto of(String month, int totalCount, int careCount, int callCount, int visitCount, int emergencyCount) {
+        return new MonthlyCareStateDto(month,totalCount, careCount, callCount, visitCount, emergencyCount);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorCountDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorCountDto.java
@@ -1,0 +1,18 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+import java.util.List;
+
+public record SeniorCountDto(
+        //전체 가구수
+        int totalCount,
+        //LED 가구수
+        int ledUseCount,
+        //Ami 가구수
+        int amiUseCount,
+
+        List<ByTownCountDto> byTownCount
+) {
+    public static SeniorCountDto of(int totalCount, int ledUseCount, int amiUseCount, List<ByTownCountDto> byTownCount) {
+        return new SeniorCountDto(totalCount, ledUseCount, amiUseCount, byTownCount);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateCountDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateCountDto.java
@@ -1,0 +1,32 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+import org.farm.fireflyserver.domain.senior.web.dto.response.SeniorStateDto;
+
+import java.util.List;
+
+public record SeniorLedStateCountDto(
+        int ledUseCount,
+
+        //정상
+        int normalCount,
+        //관심
+        int interestCount,
+        //주의
+        int cautionCount,
+        //위험
+        int dangerCount,
+
+        List<SeniorLedStateDto> seniorLedState
+) {
+    public static SeniorLedStateCountDto of(int ledUseCount, int normalCount, int interestCount, int cautionCount, int dangerCount, List<SeniorLedStateDto> seniorLedState
+    ) {
+        return new SeniorLedStateCountDto(
+                ledUseCount,
+                normalCount,
+                interestCount,
+                cautionCount,
+                dangerCount,
+                seniorLedState
+        );
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateDto.java
@@ -13,7 +13,7 @@ public record SeniorLedStateDto(
         return new SeniorLedStateDto(
                 senior.getName(),
                 managerName,
-                senior.getSeniorStatus().getDangerLevel(),
+                senior.getSeniorStatus().getDangerLevel().getLabel(),
                 senior.getSeniorStatus().getLastActTime(),
                 senior.getSeniorStatus().getState()
         );

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateDto.java
@@ -1,0 +1,21 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
+
+public record SeniorLedStateDto(
+        String name,
+        String managerName,
+        String dangerLevel,
+        int lastActTime,
+        String state
+) {
+    public static SeniorLedStateDto from(Senior senior, String managerName) {
+        return new SeniorLedStateDto(
+                senior.getName(),
+                managerName,
+                senior.getSeniorStatus().getDangerLevel(),
+                senior.getSeniorStatus().getLastActTime(),
+                senior.getSeniorStatus().getState()
+        );
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/TownStateDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/TownStateDto.java
@@ -1,0 +1,31 @@
+package org.farm.fireflyserver.domain.monitoring.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TownStateDto(
+        String townName,
+        //숫자 처리용
+        @JsonProperty("0-24") int count0_24,
+        @JsonProperty("24-48") int count24_48,
+        @JsonProperty("48-72") int count48_72,
+        @JsonProperty("72-") int count72_,
+
+        int sleepCount,
+        int memoryCount,
+        int lowEngCount,
+        int inactSCount,
+
+        int normalCount,
+        int attentionCount,
+        int cautionCount,
+        int dangerCount
+
+) {
+    public static TownStateDto of(String townName, int count0_24, int count24_48, int count48_72, int count72_,
+                                  int sleepCount, int memoryCount, int lowEngCount, int inactSCount,
+                                  int normalCount, int attentionCount, int cautionCount, int dangerCount) {
+        return new TownStateDto(townName, count0_24, count24_48, count48_72, count72_,
+                sleepCount, memoryCount, lowEngCount, inactSCount,
+                normalCount, attentionCount, cautionCount, dangerCount);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/DangerLevel.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/DangerLevel.java
@@ -1,0 +1,23 @@
+package org.farm.fireflyserver.domain.senior.persistence.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DangerLevel {
+    NORMAL("정상"),
+    ATTENTION("관심"),
+    CAUTION("주의"),
+    DANGER("위험");
+
+    private final String label;
+
+    public static DangerLevel from(String value) {
+        if (value == null) return NORMAL;
+        for (DangerLevel dl : values()) {
+            if (dl.label.equals(value)) return dl;
+        }
+        return NORMAL;
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/Senior.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/Senior.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.farm.fireflyserver.common.util.BaseCreatedTimeEntity;
 import org.farm.fireflyserver.domain.care.persistence.entity.Care;
+import org.farm.fireflyserver.domain.led.persistence.entity.LedState;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
@@ -80,11 +81,23 @@ public class Senior extends BaseCreatedTimeEntity {
     @Comment("서비스 이용 상태")
     private boolean isActive = true;
 
+    @Comment("LED 사용 여부")
+    private boolean isLedUse;
+
+    @Comment("AMI 사용 여부")
+    private boolean isAmiUse;
+
     @OneToMany(mappedBy = "senior")
     private List<Care> careList = new ArrayList<>();
 
     @OneToOne(mappedBy = "senior")
     private SeniorStatus seniorStatus;
+
+    @OneToMany(mappedBy = "senior")
+    private List<LedState> ledStates = new ArrayList<>();
+
+
+
 
 
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/SeniorStatus.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/SeniorStatus.java
@@ -40,4 +40,7 @@ public class SeniorStatus {
     //enum으로 변경 예정
     @Comment("이상징후")
     private String state;
+
+    @Comment("위험 등급")
+    private String dangerLevel;
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/SeniorStatus.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/entity/SeniorStatus.java
@@ -41,6 +41,7 @@ public class SeniorStatus {
     @Comment("이상징후")
     private String state;
 
+    @Enumerated(EnumType.STRING)
     @Comment("위험 등급")
-    private String dangerLevel;
+    private DangerLevel dangerLevel;
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
@@ -12,6 +12,7 @@ public interface SeniorRepository extends JpaRepository<Senior, Long> {
     int countByIsActiveTrue();
     int countByIsActiveTrueAndIsAmiUseTrue();
     int countByIsActiveTrueAndIsLedUseTrue();
+    List<Senior> findByIsActiveTrueAndIsLedUseTrue();
 
     @Query("""
        SELECT DISTINCT s FROM Senior s
@@ -41,4 +42,13 @@ public interface SeniorRepository extends JpaRepository<Senior, Long> {
             "WHERE s.isActive = true " +
             "GROUP BY s.town")
     List<Object[]> countByTown();
+
+    @Query("""
+    SELECT s.seniorStatus.dangerLevel, COUNT(s)
+    FROM Senior s
+    WHERE s.isActive = true AND s.isLedUse = true
+    GROUP BY s.seniorStatus.dangerLevel
+""")
+    List<Object[]> countByDangerLevel();
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
@@ -9,6 +9,10 @@ import java.util.List;
 
 public interface SeniorRepository extends JpaRepository<Senior, Long> {
 
+    int countByIsActiveTrue();
+    int countByIsActiveTrueAndIsAmiUseTrue();
+    int countByIsActiveTrueAndIsLedUseTrue();
+
     @Query("""
        SELECT DISTINCT s FROM Senior s
        LEFT JOIN s.careList c
@@ -32,4 +36,9 @@ public interface SeniorRepository extends JpaRepository<Senior, Long> {
             @Param("keyword") String keyword
     );
 
+    @Query("SELECT s.town, COUNT(s) " +
+            "FROM Senior s " +
+            "WHERE s.isActive = true " +
+            "GROUP BY s.town")
+    List<Object[]> countByTown();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/persistence/repository/SeniorRepository.java
@@ -9,10 +9,11 @@ import java.util.List;
 
 public interface SeniorRepository extends JpaRepository<Senior, Long> {
 
+    List<Senior> findAllByIsActiveTrue();
     int countByIsActiveTrue();
-    int countByIsActiveTrueAndIsAmiUseTrue();
-    int countByIsActiveTrueAndIsLedUseTrue();
     List<Senior> findByIsActiveTrueAndIsLedUseTrue();
+    int countByIsActiveTrueAndIsLedUseTrue();
+    int countByIsActiveTrueAndIsAmiUseTrue();
 
     @Query("""
        SELECT DISTINCT s FROM Senior s
@@ -37,10 +38,12 @@ public interface SeniorRepository extends JpaRepository<Senior, Long> {
             @Param("keyword") String keyword
     );
 
-    @Query("SELECT s.town, COUNT(s) " +
-            "FROM Senior s " +
-            "WHERE s.isActive = true " +
-            "GROUP BY s.town")
+    @Query("""
+    SELECT s.town, COUNT(s)
+    FROM Senior s
+    WHERE s.isActive = true
+    GROUP BY s.town
+""")
     List<Object[]> countByTown();
 
     @Query("""
@@ -51,4 +54,33 @@ public interface SeniorRepository extends JpaRepository<Senior, Long> {
 """)
     List<Object[]> countByDangerLevel();
 
+    // 위기 등급 기준
+    @Query("""
+        SELECT s.town, ss.dangerLevel, COUNT(s)
+        FROM Senior s
+        JOIN s.seniorStatus ss
+        WHERE s.isActive = true
+        GROUP BY s.town, ss.dangerLevel
+    """)
+    List<Object[]> countByTownAndDangerLevel();
+
+    // 마지막 활동 기준
+    @Query("""
+        SELECT s.town, ss.lastActTime, COUNT(s)
+        FROM Senior s
+        JOIN s.seniorStatus ss
+        WHERE s.isActive = true
+        GROUP BY s.town, ss.lastActTime
+    """)
+    List<Object[]> countByTownAndLastActTime();
+
+    // 이상 징후 기준
+    @Query("""
+        SELECT s.town, ss.state, COUNT(s)
+        FROM Senior s
+        JOIN s.seniorStatus ss
+        WHERE s.isActive = true
+        GROUP BY s.town, ss.state
+    """)
+    List<Object[]> countByTownAndState();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/web/SeniorController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/web/SeniorController.java
@@ -23,7 +23,7 @@ public class SeniorController {
     private final SeniorService seniorService;
 
     // 대상자 등록
-    @Operation(summary = "대상자 등록", description = "신규 대상자 등록(구현X)")
+    @Operation(summary = "대상자 등록(구현 X)", description = "신규 대상자 등록")
     @PostMapping
     public BaseResponse<?> registerSenior(@RequestBody RegisterSeniorDto dto) {
         seniorService.registerSenior(dto);

--- a/src/main/java/org/farm/fireflyserver/domain/senior/web/SeniorController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/web/SeniorController.java
@@ -1,5 +1,8 @@
 package org.farm.fireflyserver.domain.senior.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -13,11 +16,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/senior")
 @RequiredArgsConstructor
+@Tag(name = "Senior", description = "대상자 관련 AP" +
+        "I")
 public class SeniorController {
 
     private final SeniorService seniorService;
 
-    //대상자 등록
+    // 대상자 등록
+    @Operation(summary = "대상자 등록", description = "신규 대상자 등록(구현X)")
     @PostMapping
     public BaseResponse<?> registerSenior(@RequestBody RegisterSeniorDto dto) {
         seniorService.registerSenior(dto);
@@ -25,8 +31,8 @@ public class SeniorController {
     }
 
 
-    // 대상자 목록 정보 조회
-    //TODO : LED 데이터 정보 추가
+    // 대상자 목록 조회
+    @Operation(summary = "대상자 관리 페이지 - 대상자 목록 조회", description = "전체 대상자 정보 조회")
     @GetMapping
     public BaseResponse<?>getSeniors() {
         List<SeniorInfoDto> seniorInfo = seniorService.getSeniorInfo();
@@ -34,12 +40,14 @@ public class SeniorController {
     }
 
     // 대상자 검색
-    @GetMapping
-    @RequestMapping("/search")
+    @Operation(summary = "대상자 관리 페이지 - 대상자 검색",
+            description = "서비스 진행 여부 및 키워드 조건으로 대상자를 검색(현재는 문자열인 값들의 검색 지원하는데 수정 가능)")
+    @GetMapping("/search")
     public BaseResponse<?> searchSeniors(
-            @RequestParam(required = false)  Boolean isActive,
+            @Parameter(description = "서비스 진행 여부") @RequestParam(required = false) Boolean isActive,
+            @Parameter(description = "검색 타입 : name(이름), phone(연락처), town(읍면동), address(주소), managerName(담당자), magagerPhone(담당자 연락처), state(이상징후)")
             @RequestParam(required = false) String keywordType,
-            @RequestParam(required = false)  String keyword
+            @Parameter(description = "검색 키워드") @RequestParam(required = false) String keyword
            ) {
         List<SeniorInfoDto> seniorInfo = seniorService.searchSeniors(isActive,keywordType,keyword);
         return BaseResponse.of(SuccessCode.OK, seniorInfo);


### PR DESCRIPTION
## 💡 관련 이슈
- close : #24
 
## 💡 작업 사항
- 메인 홈 4가지 페이지 레이아웃별로 객체 분리해서 구현했습니다! (API는 하나) => 추후 디벨롭 예정
- 스웨거 명세 작성

## 💡 참고 사항
- `지역별 대상자 상태 현황` 필터링 적용할까 고민중인데 아직은 적용전이어서 전체 정보 한 번에 반환합니다 
=> 이 부분이랑 중복되는 부분 코드 수정이 좀 필요할 거 같은데 구현이 우선이어서 먼저 올렸습니당
- swagger 작성 예시는 아래 커밋 참고하면 될 거 같슴다
[docs :](https://github.com/firefly-care/firefly-care-server/commit/ec4c0f7ca23f48926656f2199b27bf6d344e8b8c) https://github.com/firefly-care/firefly-care-server/issues/24 [대상자 검색, 조회 swagger 명세 추가](https://github.com/firefly-care/firefly-care-server/commit/ec4c0f7ca23f48926656f2199b27bf6d344e8b8c)
- 확인 후 괜찮으면 merge 부탁!