### PR TITLE
fix : batch 시간 초기화 문제

### DIFF
--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
@@ -1,24 +1,37 @@
 package org.farm.fireflyserver.domain.led.persistence.repository;
 
 import org.farm.fireflyserver.domain.led.persistence.entity.LedHistory;
+import org.farm.fireflyserver.domain.led.persistence.entity.OnOff;
 import org.farm.fireflyserver.domain.led.persistence.entity.SensorGbn;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LedHistoryRepository extends JpaRepository<LedHistory, Long> {
 
+    //중복 체크
+    boolean existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
+            String ledMtchnSn, SensorGbn sensorGbn, OnOff onOff, LocalDateTime eventTime);
+
     // 특정 LED센서 최신 데이터 조회
-    LedHistory findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDesc(String s, SensorGbn sensorGbn);
+    LedHistory findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDescLedHistoryIdDesc(String ledMtchnSn, SensorGbn sensorGbn);
 
     // 모든 LED센서 최신 데이터 조회
-    @Query("""
-                SELECT l FROM LedHistory l
-                WHERE l.ledHistoryId IN (
-                    SELECT MAX(l2.ledHistoryId) FROM LedHistory l2 GROUP BY l2.ledMtchnSn, l2.sensorGbn
-                )
-            """)
-
-    List<LedHistory> findLatestHistories();
+    //JPQL에서 일부 기능 사용 불가하여 NativeQuery 사용
+    @Query(value = """
+    SELECT l.*
+    FROM led_history l
+    JOIN (
+        SELECT t.led_mtchn_sn, t.sensor_gbn, MAX(t.led_history_id) AS max_id
+        FROM led_history t
+        WHERE t.on_off = 'ON'
+          AND t.event_time >= :start
+        GROUP BY t.led_mtchn_sn, t.sensor_gbn
+    ) latest
+      ON l.led_history_id = latest.max_id
+""", nativeQuery = true)
+    List<LedHistory> findLatestHistories(@Param("start") LocalDateTime start);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
@@ -126,6 +126,7 @@ public class LedBatchConfig {
     }
 
 
+    /*
     //바로 실행용
     @Bean
     public CommandLineRunner runLedHistoryJob(Job ledHistoryJob) {
@@ -143,7 +144,6 @@ public class LedBatchConfig {
             System.out.println("[Batch] ledHistoryJob finished at " + LocalDateTime.now());
         };
     }
-
-
+    */
 
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Configuration
 @EnableBatchProcessing
@@ -135,7 +136,7 @@ public class LedBatchConfig {
             jobLauncher.run(
                     ledHistoryJob,
                     new JobParametersBuilder()
-                            .addLong("run.id", now)
+                            .addString("run.id", UUID.randomUUID().toString())
                             .addLong("window.now", now)
                             .toJobParameters()
             );

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchConfig.java
@@ -7,19 +7,24 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,37 +36,75 @@ public class LedBatchConfig {
     private final PlatformTransactionManager transactionManager;
     private final LedHistoryRepository ledHistoryRepository;
     private final JobLauncher jobLauncher;
-    private final ApplicationContext context;
 
-    // 최신 10분 ON 로그를 저장하는 Map 결과 누적용
+    // 공톹 시간 Map
     @Bean
+    @JobScope
+    public Map<String, LocalDateTime> windowTimes(
+            @Value("#{jobParameters['window.now']}") Long nowEpochMillis,
+            @Value("${app.timezone:Asia/Seoul}") String appTimezone
+    ) {
+        LocalDateTime now = Instant.ofEpochMilli(nowEpochMillis)
+                .atZone(ZoneId.of(appTimezone))
+                .toLocalDateTime();
+
+        Map<String, LocalDateTime> map = new HashMap<>();
+        map.put("now", now);
+        map.put("windowStart", now.minusMinutes(10));
+        return map;
+    }
+
+    // 최신 10분 ON 로그를 저장하는 Map 결과 누적용 (Processor ↔ Listener 공유)
+    @Bean
+    @JobScope
     public Map<String, LedDataLogDto> latestMap() {
         return new HashMap<>();
     }
 
     @Bean
+    @StepScope
     public LedItemProcessor ledItemProcessor(Map<String, LedDataLogDto> latestMap) {
         return new LedItemProcessor(latestMap);
     }
 
     @Bean
-    public LedJobListener ledJobListener(Map<String, LedDataLogDto> latestMap) {
-        return new LedJobListener(ledHistoryRepository, latestMap);
+    @JobScope
+    public LedJobListener ledJobListener(Map<String, LedDataLogDto> latestMap, Map<String, LocalDateTime> windowTimes) {
+        return new LedJobListener(ledHistoryRepository, latestMap, windowTimes);
+    }
+
+
+    // 실행(now) 기준 10분 윈도우를 계산하는 Reader
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<LedDataLogDto> ledItemReader(
+            @Qualifier("ledDataSource") DataSource ledDataSource,
+            Map<String, LocalDateTime> windowTimes
+    ) {
+        return LedItemReader.reader(ledDataSource, windowTimes);
+    }
+
+
+    @Bean
+    @StepScope
+    public LedItemWriter ledItemWriter(
+            LedHistoryRepository ledHistoryRepository,
+            Map<String, LocalDateTime> windowTimes
+    ) {
+        return new LedItemWriter(ledHistoryRepository, windowTimes);
     }
 
     // LED 데이터 히스토리 저장 배치 Job
     // ledDataSource : 실제 LED 센서 로그 받아오는 DB
     @Bean
     public Job ledHistoryJob(JobRepository jobRepository,
-                             @Qualifier("ledDataSource") DataSource ledDataSource,
                              LedJobListener ledJobListener,
-                             LedItemProcessor ledItemProcessor) {
+                             Step ledHistoryStep) {
         return new JobBuilder("ledHistoryJob", jobRepository)
                 .listener(ledJobListener)
-                .start(ledHistoryStep(jobRepository, ledDataSource, ledItemProcessor))
+                .start(ledHistoryStep)
                 .build();
     }
-
 
     // LED 데이터 히스토리 저장 배치 Step
     // 1. reader에서 10분 이내 LED 센서 로그를 읽기
@@ -70,50 +113,36 @@ public class LedBatchConfig {
     // 4. jobListener에서 ON 상태였는데 processor(최신 10분 ON 로그)에 없으면 OFF 이벤트 추가
     @Bean
     public Step ledHistoryStep(JobRepository jobRepository,
-                               DataSource ledDataSource,
-                               LedItemProcessor ledItemProcessor) {
+                               LedItemProcessor ledItemProcessor,
+                               JdbcCursorItemReader<LedDataLogDto> ledItemReader,
+                               LedItemWriter ledItemWriter) {
         return new StepBuilder("ledHistoryStep", jobRepository)
                 .<LedDataLogDto, Map<String, LedDataLogDto>>chunk(500, transactionManager)
-                .reader(LedItemReader.reader(ledDataSource))
+                .reader(ledItemReader)
                 .processor(ledItemProcessor)
-                .writer(new LedItemWriter(ledHistoryRepository))
+                .writer(ledItemWriter)
                 .build();
     }
 
-    @Scheduled(cron = "0 0/10 * * * *")
-    public void runScheduledLedHistoryJob() throws Exception {
-        System.out.println("[Scheduled Batch] ledHistoryJob started at " + LocalDateTime.now());
 
-        Map<String, LedDataLogDto> latestMap = context.getBean("latestMap", Map.class);
-        latestMap.clear();
-
-        Job ledHistoryJob = context.getBean("ledHistoryJob", Job.class);
-
-        jobLauncher.run(
-                ledHistoryJob,
-                new JobParametersBuilder()
-                        .addLong("time", System.currentTimeMillis())
-                        .toJobParameters()
-        );
-        System.out.println("[Scheduled Batch] ledHistoryJob finished at " + LocalDateTime.now());
-    }
-
-
-   /*
+    //바로 실행용
     @Bean
     public CommandLineRunner runLedHistoryJob(Job ledHistoryJob) {
         return args -> {
             System.out.println("[Batch] ledHistoryJob started at " + LocalDateTime.now());
+
+            long now = System.currentTimeMillis();
             jobLauncher.run(
                     ledHistoryJob,
                     new JobParametersBuilder()
-                            .addLong("time", System.currentTimeMillis())
+                            .addLong("run.id", now)
+                            .addLong("window.now", now)
                             .toJobParameters()
             );
             System.out.println("[Batch] ledHistoryJob finished at " + LocalDateTime.now());
         };
     }
-    */
+
 
 
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchScheduler.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchScheduler.java
@@ -1,0 +1,34 @@
+package org.farm.fireflyserver.domain.led.service.batch;
+
+import lombok.AllArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+
+@Configuration
+@AllArgsConstructor
+public class LedBatchScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job ledHistoryJob;
+
+    @Scheduled(cron = "0 0/10 * * * *", zone = "${app.timezone:Asia/Seoul}")
+    public void runScheduledLedHistoryJob() throws Exception {
+
+        long now = System.currentTimeMillis();
+        jobLauncher.run(
+                ledHistoryJob,
+                new JobParametersBuilder()
+                        .addLong("run.id", now)
+                        .addLong("window.now", now)
+                        .toJobParameters()
+        );
+    }
+
+}
+
+
+

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchScheduler.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedBatchScheduler.java
@@ -8,6 +8,8 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import java.util.UUID;
+
 
 @Configuration
 @AllArgsConstructor
@@ -15,15 +17,15 @@ public class LedBatchScheduler {
     private final JobLauncher jobLauncher;
     private final Job ledHistoryJob;
 
-    @Scheduled(cron = "0 0/10 * * * *", zone = "${app.timezone:Asia/Seoul}")
+    //임시 : 5분 스케줄링
+    @Scheduled(cron = "0 */5 * * * *", zone = "${app.timezone:Asia/Seoul}")
     public void runScheduledLedHistoryJob() throws Exception {
-
         long now = System.currentTimeMillis();
         jobLauncher.run(
                 ledHistoryJob,
                 new JobParametersBuilder()
-                        .addLong("run.id", now)
-                        .addLong("window.now", now)
+                        .addString("run.id", UUID.randomUUID().toString()) //job 식별자
+                        .addLong("window.now", now) // 배치 시간
                         .toJobParameters()
         );
     }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemReader.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemReader.java
@@ -1,24 +1,22 @@
 package org.farm.fireflyserver.domain.led.service.batch;
 
-import org.farm.fireflyserver.domain.led.web.dto.response.LedDataLogDto;
 import org.farm.fireflyserver.domain.led.persistence.entity.SensorGbn;
-import org.springframework.batch.item.ItemReader;
+import org.farm.fireflyserver.domain.led.web.dto.response.LedDataLogDto;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
 import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
 
 import javax.sql.DataSource;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-
+import java.util.Map;
 
 // 10분 이내 LED 센서 로그를 읽어오는 ItemReader
 public class LedItemReader {
 
-    public static ItemReader<LedDataLogDto> reader(DataSource ledDataSource) {
+    public static JdbcCursorItemReader<LedDataLogDto> reader(DataSource ledDataSource, Map<String, LocalDateTime> windowTimes) {
 
-        LocalDateTime now = LocalDateTime.now();
-
-        Timestamp start = Timestamp.valueOf(now.minusMinutes(10));
-        Timestamp end = Timestamp.valueOf(now);
+        Timestamp start = Timestamp.valueOf(windowTimes.get("windowStart"));
+        Timestamp now = Timestamp.valueOf(windowTimes.get("now"));
 
         return new JdbcCursorItemReaderBuilder<LedDataLogDto>()
                 .name("ledSensorLogReader")
@@ -27,13 +25,14 @@ public class LedItemReader {
                         "FROM t_led_sensor_log " +
                         "WHERE REG_DT >= ? AND REG_DT < ? " +
                         "ORDER BY REG_DT DESC")
-                .queryArguments(start, end)
-                .rowMapper((rs, rowNum) -> new LedDataLogDto(
-                        rs.getString("LED_MTCHN_SN"),
-                        SensorGbn.fromCode(rs.getString("LED_SENSOR_GBN")),
-                        rs.getTimestamp("REG_DT").toLocalDateTime(),
-                        null
-                ))
+                .queryArguments(start, now)
+                .rowMapper((rs, rowNum) -> {
+                    String ledMtchnSn = rs.getString("LED_MTCHN_SN");
+                    SensorGbn sensorGbn = SensorGbn.fromCode(rs.getString("LED_SENSOR_GBN"));
+                    LocalDateTime eventTime = rs.getTimestamp("REG_DT").toLocalDateTime();
+                    return new LedDataLogDto(ledMtchnSn, sensorGbn, eventTime,null);
+                }
+                )
                 .build();
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemWriter.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemWriter.java
@@ -9,25 +9,38 @@ import org.farm.fireflyserver.domain.led.web.dto.response.LedDataLogDto;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 // 최신 ON 이벤트를 LED 히스토리에 저장 & 업데이트하는 Writer
 @RequiredArgsConstructor
 public class LedItemWriter implements ItemWriter<Map<String, LedDataLogDto>> {
 
     private final LedHistoryRepository ledHistoryRepository;
+    private final Map<String, LocalDateTime> windowTimes;
+    private final Map<String, LocalDateTime> lastWritten = new HashMap<>();
 
     @Override
-    public void write(Chunk<? extends Map<String, LedDataLogDto>> chunk) throws Exception {
+    public void write(Chunk<? extends Map<String, LedDataLogDto>> chunk ) {
 
         Map<String, LedDataLogDto> latestMap = new HashMap<>();
+
+        final LocalDateTime start = windowTimes.get("windowStart");
+        final LocalDateTime now = windowTimes.get("now");
 
         // 청크 단위로 Processor에서 온 최신 ON 로그 병합
         for (Map<String, LedDataLogDto> map : chunk) {
             for (Map.Entry<String, LedDataLogDto> entry : map.entrySet()) {
                 String key = entry.getKey();
                 LedDataLogDto dto = entry.getValue();
+
+                //임시 : 시간 재검증용
+                if (dto.eventTime().isBefore(start) || !dto.eventTime().isBefore(now)) {
+                    continue;
+                }
 
                 LedDataLogDto existing = latestMap.get(key);
                 if (existing == null || existing.eventTime().isBefore(dto.eventTime())) {
@@ -36,33 +49,69 @@ public class LedItemWriter implements ItemWriter<Map<String, LedDataLogDto>> {
             }
         }
 
-        // ON 이벤트 처리
+        // ON 이벤트 처리 결과 저장용
+        List<LedHistory> toSave = getSaveList(latestMap);
+
+        if (!toSave.isEmpty()) {
+            ledHistoryRepository.saveAll(toSave);
+        }
+    }
+
+    private List<LedHistory> getSaveList(Map<String, LedDataLogDto> latestMap) {
+        List<LedHistory> toSave = new ArrayList<>();
+
         for (Map.Entry<String, LedDataLogDto> entry : latestMap.entrySet()) {
             String key = entry.getKey();
             LedDataLogDto dto = entry.getValue();
-            String[] parts = key.split("_");
 
+            LocalDateTime prev = lastWritten.get(key);
+            if (prev != null && !dto.eventTime().isAfter(prev)) {
+                continue;
+            }
+
+            String[] parts = key.split("_", 2);
             String ledMtchnSn = parts[0];
             SensorGbn sensorGbn = SensorGbn.fromCode(parts[1]);
 
-            // 해당 LED센서의 최신 히스토리 조회
-            LedHistory latestHistory = ledHistoryRepository
-                    .findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDesc(ledMtchnSn, sensorGbn);
-
-            // CASE 1: DB 없음 → Processor 있음 → ON 이벤트 추가
-            if (latestHistory == null) {
-                ledHistoryRepository.save(dto.toLedHistory(OnOff.ON));
-            }
-            // CASE 2: DB 있음(OFF) → Processor 있음 → ON 이벤트 추가
-            else if (latestHistory.getOnOff() == OnOff.OFF) {
-                ledHistoryRepository.save(dto.toLedHistory(OnOff.ON));
-            }
-            // CASE 3: DB 있음(ON) → Processor 있음 → eventTime 시간 업데이트
-            else if (latestHistory.getOnOff() == OnOff.ON &&
-                    !latestHistory.getEventTime().isEqual(dto.eventTime())) {
-                latestHistory.updateEventTime(dto.eventTime());
-                ledHistoryRepository.save(latestHistory);
+            LedHistory candidate = decideUpsert(ledMtchnSn, sensorGbn, dto);
+            if (candidate != null) {
+                toSave.add(candidate);
+                lastWritten.put(key, dto.eventTime());
             }
         }
+
+        return toSave;
+    }
+
+
+    private LedHistory decideUpsert(String ledMtchnSn, SensorGbn sensorGbn, LedDataLogDto dto) {
+        // 해당 LED센서의 최신 히스토리 조회
+        LedHistory latestHistory = ledHistoryRepository
+                .findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDescLedHistoryIdDesc(ledMtchnSn, sensorGbn);
+
+        // CASE 1: DB 없음 → Processor 있음 → ON 이벤트 추가
+        if (latestHistory == null) {
+            if (!ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
+                    ledMtchnSn, sensorGbn, OnOff.ON, dto.eventTime())) {
+                return dto.toLedHistory(OnOff.ON);
+            }
+            return null;
+        }
+        // CASE 2: DB 있음(OFF) → Processor 있음 → ON 이벤트 추가
+        else if (latestHistory.getOnOff() == OnOff.OFF) {
+            if (!ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
+                    ledMtchnSn, sensorGbn, OnOff.ON, dto.eventTime())) {
+                return dto.toLedHistory(OnOff.ON);
+            }
+            return null;
+        }
+        // CASE 3: DB 있음(ON) → Processor 있음 → eventTime 시간 업데이트
+        else if (latestHistory.getOnOff() == OnOff.ON &&
+                !latestHistory.getEventTime().isEqual(dto.eventTime())) {
+            latestHistory.updateEventTime(dto.eventTime());
+            return latestHistory;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedJobListener.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedJobListener.java
@@ -1,6 +1,9 @@
 package org.farm.fireflyserver.domain.led.service.batch;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.farm.fireflyserver.domain.led.persistence.entity.LedHistory;
 import org.farm.fireflyserver.domain.led.persistence.entity.OnOff;
 import org.farm.fireflyserver.domain.led.persistence.repository.LedHistoryRepository;
@@ -14,28 +17,57 @@ import java.util.Map;
 
 // Job 종료 후, 최신 ON 이벤트가 Processor에 없으면 OFF 이벤트 추가
 @RequiredArgsConstructor
+@Slf4j
 public class LedJobListener extends JobExecutionListenerSupport {
 
     private final LedHistoryRepository ledHistoryRepository;
     private final Map<String, LedDataLogDto> latestMap;
+    private final Map<String, LocalDateTime> windowTimes;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     // CASE 4: DB 있음(ON) → Processor 없음 → OFF 이벤트 추가
     @Override
     public void afterJob(JobExecution jobExecution) {
-        List<LedHistory> allHistories = ledHistoryRepository.findLatestHistories();
+        // 배치 기준 시각(now)과 윈도우 시작 계산
+        final LocalDateTime start = windowTimes.get("windowStart");
+        final LocalDateTime now = windowTimes.get("now");
+
+        entityManager.clear();  // 캐시 초기화
+
+        // 모든 LED센서 최신 데이터 조회
+        List<LedHistory> allHistories = ledHistoryRepository.findLatestHistories(start);
+
+        //로그
+        allHistories.forEach(h ->
+                log.info("[Listener] latest id={}, sn={}, gbn={}, onOff={}, eventTime={}",
+                        h.getLedHistoryId(), h.getLedMtchnSn(), h.getSensorGbn(),
+                        h.getOnOff(), h.getEventTime())
+        );
 
         for (LedHistory history : allHistories) {
             String key = history.getLedMtchnSn() + "_" + history.getSensorGbn().getCode();
-            if (!latestMap.containsKey(key) && history.getOnOff() == OnOff.ON) {
-                LedHistory offHistory = LedHistory.builder()
-                        .ledMtchnSn(history.getLedMtchnSn())
-                        .sensorGbn(history.getSensorGbn())
-                        .onOff(OnOff.OFF)
-                        .eventTime(LocalDateTime.now())
-                        .build();
-                ledHistoryRepository.save(offHistory);
+
+            // 스킵
+            if (history.getOnOff() != OnOff.ON || latestMap.containsKey(key)) {
+                continue;
             }
+
+            boolean offExists = ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
+                    history.getLedMtchnSn(), history.getSensorGbn(), OnOff.OFF, now);
+            if (offExists) {
+                continue;
+            }
+
+            // OFF 이벤트 추가
+            LedHistory offHistory = LedHistory.builder()
+                    .ledMtchnSn(history.getLedMtchnSn())
+                    .sensorGbn(history.getSensorGbn())
+                    .onOff(OnOff.OFF)
+                    .eventTime(now)
+                    .build();
+            ledHistoryRepository.save(offHistory);
         }
     }
 }
-


### PR DESCRIPTION
## 💡 관련 이슈
- close : #38 
 
## 💡 작업 사항
- 문제 예상 원인 : Job/Step 관련 스프링 빈 생성 시점에 ItemReader에서 사용하는 현재 시간(now)을 고정해버림 (= 어플리케이션이 시작되는 시점에 고정된다는 뜻)
- 에러 수정 사항 
  - 배치마다 현재 시간 기준으로 공통 시간 포맷 정의
  - 그 외 여러 가지 시도들 : 최신 로그 조회 방식 변경 (JPQL -> Native쿼리 변경), 리스너 캐시 초기화, 중복 체크 함수 추가
- 리팩토링 사항 
   - 스케줄링에서 Job를 가져올 때 발생했던 순환참조 문제 해결 위한 파일 분리, 함수 분리

## 💡 참고 사항
근데 희한하게 바로 실행했을 때랑 스케줄링도 되긴하는데 딱 10분 스케줄링 설정했을 때만 데이터 읽어오는 값이 이상한 문제가 있습니다....뭔가 정각 충돌이 있는건지....일단은 5분 스케줄링으로 설정해서 되는지 시도 해보려구합니다...
