### PR TITLE
담당자 페이지 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,13 @@ dependencies {
     //jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+
     //spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
@@ -54,11 +61,20 @@ dependencies {
     //spring batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 
-    //spring-doc(swagger)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
-
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += 'build/generated/querydsl'
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file("build/generated/querydsl"))
 }

--- a/src/main/java/org/farm/fireflyserver/common/config/QuerydslConfig.java
+++ b/src/main/java/org/farm/fireflyserver/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package org.farm.fireflyserver.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface CareRepository extends JpaRepository<Care, Long> {
+public interface CareRepository extends JpaRepository<Care, Long>, CareRepositoryCustom {
     @Query("SELECT c FROM Care c " +
             "LEFT JOIN c.managerAccount m " +
             "LEFT JOIN c.senior s WHERE " +

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryCustom.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryCustom.java
@@ -1,7 +1,11 @@
 package org.farm.fireflyserver.domain.care.persistence;
 
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+
 import java.util.List;
 
 public interface CareRepositoryCustom {
     List<Long> findDistinctSeniorIdsByManagerId(Long managerId);
+    List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryCustom.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryCustom.java
@@ -1,0 +1,7 @@
+package org.farm.fireflyserver.domain.care.persistence;
+
+import java.util.List;
+
+public interface CareRepositoryCustom {
+    List<Long> findDistinctSeniorIdsByManagerId(Long managerId);
+}

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
@@ -36,7 +36,7 @@ public class CareRepositoryImpl implements CareRepositoryCustom {
                                 "TIMESTAMPDIFF(YEAR, {0}, CURDATE())",
                                 senior.birthday
                         ),
-                        care.date,
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d')", care.date),
                         care.result
                 ))
                 .from(care)

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
@@ -1,9 +1,15 @@
 package org.farm.fireflyserver.domain.care.persistence;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+
 import java.util.List;
 import static org.farm.fireflyserver.domain.care.persistence.entity.QCare.care;
+import static org.farm.fireflyserver.domain.senior.persistence.entity.QSenior.senior;
 
 @RequiredArgsConstructor
 public class CareRepositoryImpl implements CareRepositoryCustom {
@@ -16,5 +22,30 @@ public class CareRepositoryImpl implements CareRepositoryCustom {
                 .from(care)
                 .where(care.manager.managerId.eq(managerId))
                 .fetch();
+    }
+
+    @Override
+    public List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType) {
+        List<ManagerDto.CareSeniorInfo> dtos =  queryFactory
+                .select(Projections.constructor(
+                        ManagerDto.CareSeniorInfo.class,
+                        senior.name,
+                        senior.gender,
+                        Expressions.numberTemplate(
+                                Long.class,
+                                "TIMESTAMPDIFF(YEAR, {0}, CURDATE())",
+                                senior.birthday
+                        ),
+                        care.date,
+                        care.result
+                ))
+                .from(care)
+                .join(care.senior, senior)
+                .where(
+                        care.manager.managerId.eq(managerId),
+                        care.type.eq(careType)
+                )
+                .fetch();
+        return dtos;
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
@@ -1,0 +1,20 @@
+package org.farm.fireflyserver.domain.care.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+import static org.farm.fireflyserver.domain.care.persistence.entity.QCare.care;
+
+@RequiredArgsConstructor
+public class CareRepositoryImpl implements CareRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findDistinctSeniorIdsByManagerId(Long managerId) {
+        return queryFactory
+                .select(care.senior.seniorId).distinct()
+                .from(care)
+                .where(care.manager.managerId.eq(managerId))
+                .fetch();
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CareRepositoryImpl implements CareRepositoryCustom {
 
     @Override
     public List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType) {
-        List<ManagerDto.CareSeniorInfo> dtos =  queryFactory
+        return queryFactory
                 .select(Projections.constructor(
                         ManagerDto.CareSeniorInfo.class,
                         senior.name,
@@ -46,6 +46,5 @@ public class CareRepositoryImpl implements CareRepositoryCustom {
                         care.type.eq(careType)
                 )
                 .fetch();
-        return dtos;
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/entity/Care.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/entity/Care.java
@@ -3,6 +3,7 @@ package org.farm.fireflyserver.domain.care.persistence.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.farm.fireflyserver.domain.account.persistence.entity.Account;
+import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 
 
@@ -23,9 +24,14 @@ public class Care extends BaseCreatedTimeEntity {
     private Long careId;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_account_id")
+    @Comment("돌봄 담당자 계정")
+    private Account managerAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id")
     @Comment("돌봄 담당자")
-    private Account managerAccount;
+    private Manager manager;
 
     @Comment("돌봄 일시")
     private LocalDateTime date;

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareService.java
@@ -10,4 +10,5 @@ public interface CareService {
     List<CareDto.Response> getAllCare();
     List<CareDto.Response> searchCare(CareDto.SearchRequest request);
     CareDto.MonthlyCare getSeniorMonthlyCare(Long seniorId, YearMonth yearMonth);
+    List<Long> getSeniorIdsByManagerId(Long managerId);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareService.java
@@ -1,6 +1,8 @@
 package org.farm.fireflyserver.domain.care.service;
 
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.care.web.dto.CareDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 
 import java.time.YearMonth;
 import java.util.List;
@@ -11,4 +13,5 @@ public interface CareService {
     List<CareDto.Response> searchCare(CareDto.SearchRequest request);
     CareDto.MonthlyCare getSeniorMonthlyCare(Long seniorId, YearMonth yearMonth);
     List<Long> getSeniorIdsByManagerId(Long managerId);
+    List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
@@ -123,4 +123,9 @@ public class CareServiceImpl implements CareService {
 
         return new CareDto.MonthlyCare(callCnt, visitCnt, emergCnt, careTuples);
     }
+
+    @Override
+    public List<Long> getSeniorIdsByManagerId(Long managerId) {
+        return careRepository.findDistinctSeniorIdsByManagerId(managerId);
+    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
@@ -18,6 +18,7 @@ import org.farm.fireflyserver.domain.care.persistence.entity.CareResult;
 import org.farm.fireflyserver.domain.care.web.dto.AbsentCareDetailsDto;
 import org.farm.fireflyserver.domain.care.web.dto.CareDto;
 import org.farm.fireflyserver.domain.care.web.dto.NormalCareDetailsDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorRepository;
 import org.springframework.stereotype.Service;
@@ -127,5 +128,10 @@ public class CareServiceImpl implements CareService {
     @Override
     public List<Long> getSeniorIdsByManagerId(Long managerId) {
         return careRepository.findDistinctSeniorIdsByManagerId(managerId);
+    }
+
+    @Override
+    public List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType) {
+        return careRepository.getCareSeniorInfoByManagerAndCareType(managerId, careType);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepository.java
@@ -1,0 +1,7 @@
+package org.farm.fireflyserver.domain.manager.persistence;
+
+import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerRepository extends JpaRepository<Manager, Long>, ManagerRepositoryCustom {
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryCustom.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.farm.fireflyserver.domain.manager.persistence;
+
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+
+import java.util.List;
+
+public interface ManagerRepositoryCustom {
+    List<ManagerDto.SimpleInfo> findManagerSimpleInfoList();
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryCustom.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryCustom.java
@@ -3,7 +3,9 @@ package org.farm.fireflyserver.domain.manager.persistence;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ManagerRepositoryCustom {
     List<ManagerDto.SimpleInfo> findManagerSimpleInfoList();
+    Optional<ManagerDto.DetailInfo> findDetailInfoById(Long id);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.farm.fireflyserver.domain.manager.persistence.entity.QManager.manager;
 
@@ -25,5 +26,24 @@ public class ManagerRepositoryImpl implements ManagerRepositoryCustom {
                 ))
                 .from(manager)
                 .fetch();
+    }
+
+    @Override
+    public Optional<ManagerDto.DetailInfo> findDetailInfoById(Long id) {
+        ManagerDto.DetailInfo dto =  queryFactory
+                .select(Projections.constructor(ManagerDto.DetailInfo.class,
+                        manager.managerId,
+                        manager.name,
+                        manager.phoneNum,
+                        manager.birth,
+                        manager.affiliation,
+                        manager.email,
+                        manager.address
+                ))
+                .from(manager)
+                .where(manager.managerId.eq(id))
+                .fetchOne();
+
+        return Optional.ofNullable(dto);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
@@ -17,6 +17,7 @@ public class ManagerRepositoryImpl implements ManagerRepositoryCustom {
     public List<ManagerDto.SimpleInfo> findManagerSimpleInfoList() {
         return queryFactory
                 .select(Projections.constructor(ManagerDto.SimpleInfo.class,
+                        manager.managerId,
                         manager.name,
                         manager.seniorCnt,
                         manager.careCnt,

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepositoryImpl.java
@@ -1,0 +1,28 @@
+package org.farm.fireflyserver.domain.manager.persistence;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+
+import java.util.List;
+
+import static org.farm.fireflyserver.domain.manager.persistence.entity.QManager.manager;
+
+@RequiredArgsConstructor
+public class ManagerRepositoryImpl implements ManagerRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ManagerDto.SimpleInfo> findManagerSimpleInfoList() {
+        return queryFactory
+                .select(Projections.constructor(ManagerDto.SimpleInfo.class,
+                        manager.name,
+                        manager.seniorCnt,
+                        manager.careCnt,
+                        manager.recentCareDate
+                ))
+                .from(manager)
+                .fetch();
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
@@ -1,0 +1,55 @@
+package org.farm.fireflyserver.domain.manager.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDate;
+
+@Table(name = "manager")
+@Entity
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Manager {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("담당자 PK")
+    private Long managerId;
+
+    @Column(nullable = false, length = 25)
+    @Comment("이름")
+    private String name;
+
+    @Column(length = 25)
+    @Comment("연락처")
+    private String phoneNum;
+
+    @Comment("생년월일")
+    private LocalDate birth;
+
+    @Column(length = 25)
+    @Comment("소속")
+    private String affiliation;
+
+    @Column(length = 25)
+    @Comment("이메일")
+    private String email;
+
+    @Column(length = 50)
+    @Comment("주소")
+    private String address;
+
+    @Comment("돌봄 건수")
+    private Long seniorCnt;
+
+    @Comment("대상자 수")
+    private Long careCnt;
+
+    @Comment("최근 돌봄 일자")
+    private LocalDate recentCareDate;
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
@@ -5,9 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.farm.fireflyserver.domain.care.persistence.entity.Care;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Table(name = "manager")
 @Entity
@@ -52,4 +55,7 @@ public class Manager {
 
     @Comment("최근 돌봄 일자")
     private LocalDate recentCareDate;
+
+    @OneToMany(mappedBy = "manager")
+    private List<Care> careList = new ArrayList<>();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ManagerService {
     public List<ManagerDto.SimpleInfo> getAllManagers();
+    public ManagerDto.DetailInfo getManagerById(Long id);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -1,5 +1,6 @@
 package org.farm.fireflyserver.domain.manager.service;
 
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 
 import java.util.List;
@@ -8,4 +9,5 @@ public interface ManagerService {
     List<ManagerDto.SimpleInfo> getAllManagers();
     ManagerDto.DetailInfo getManagerById(Long id);
     List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id);
+    List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface ManagerService {
     public List<ManagerDto.SimpleInfo> getAllManagers();
     public ManagerDto.DetailInfo getManagerById(Long id);
+    public List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -1,0 +1,9 @@
+package org.farm.fireflyserver.domain.manager.service;
+
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+
+import java.util.List;
+
+public interface ManagerService {
+    public List<ManagerDto.SimpleInfo> getAllManagers();
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -5,7 +5,7 @@ import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import java.util.List;
 
 public interface ManagerService {
-    public List<ManagerDto.SimpleInfo> getAllManagers();
-    public ManagerDto.DetailInfo getManagerById(Long id);
-    public List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id);
+    List<ManagerDto.SimpleInfo> getAllManagers();
+    ManagerDto.DetailInfo getManagerById(Long id);
+    List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
@@ -1,0 +1,19 @@
+package org.farm.fireflyserver.domain.manager.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerServiceImpl implements ManagerService {
+    private final ManagerRepository managerRepository;
+
+    @Override
+    public List<ManagerDto.SimpleInfo> getAllManagers() {
+        return managerRepository.findManagerSimpleInfoList();
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
@@ -3,9 +3,12 @@ package org.farm.fireflyserver.domain.manager.service;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.exception.EntityNotFoundException;
 import org.farm.fireflyserver.common.response.ErrorCode;
+import org.farm.fireflyserver.domain.care.service.CareService;
 import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.farm.fireflyserver.domain.senior.service.SeniorService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -13,6 +16,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ManagerServiceImpl implements ManagerService {
     private final ManagerRepository managerRepository;
+    private final SeniorService seniorService;
+    private final CareService careService;
 
     @Override
     public List<ManagerDto.SimpleInfo> getAllManagers() {
@@ -23,5 +28,17 @@ public class ManagerServiceImpl implements ManagerService {
     public ManagerDto.DetailInfo getManagerById(Long id) {
         return managerRepository.findDetailInfoById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id) {
+        if (!managerRepository.existsById(id)) {
+            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
+        }
+
+        List<Long> seniorIds = careService.getSeniorIdsByManagerId(id);
+
+        return seniorService.getSeniorInfoByIds(seniorIds);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
@@ -3,6 +3,7 @@ package org.farm.fireflyserver.domain.manager.service;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.exception.EntityNotFoundException;
 import org.farm.fireflyserver.common.response.ErrorCode;
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.care.service.CareService;
 import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
@@ -40,5 +41,15 @@ public class ManagerServiceImpl implements ManagerService {
         List<Long> seniorIds = careService.getSeniorIdsByManagerId(id);
 
         return seniorService.getSeniorInfoByIds(seniorIds);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType) {
+        if (!managerRepository.existsById(managerId)) {
+            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
+        }
+
+        return careService.getCareSeniorInfoByManagerAndCareType(managerId, careType);
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
@@ -1,6 +1,8 @@
 package org.farm.fireflyserver.domain.manager.service;
 
 import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.common.exception.EntityNotFoundException;
+import org.farm.fireflyserver.common.response.ErrorCode;
 import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.springframework.stereotype.Service;
@@ -15,5 +17,11 @@ public class ManagerServiceImpl implements ManagerService {
     @Override
     public List<ManagerDto.SimpleInfo> getAllManagers() {
         return managerRepository.findManagerSimpleInfoList();
+    }
+
+    @Override
+    public ManagerDto.DetailInfo getManagerById(Long id) {
+        return managerRepository.findDetailInfoById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -6,6 +6,7 @@ import org.farm.fireflyserver.common.response.SuccessCode;
 import org.farm.fireflyserver.domain.manager.service.ManagerService;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,5 +25,10 @@ public class ManagerController {
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
 
+    @GetMapping("/{id}")
+    public BaseResponse<?> getManagerById(@PathVariable Long id) {
+        ManagerDto.DetailInfo dto = managerService.getManagerById(id);
 
+        return BaseResponse.of(SuccessCode.OK, dto);
+    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -1,0 +1,26 @@
+package org.farm.fireflyserver.domain.manager.web;
+
+import lombok.RequiredArgsConstructor;
+import org.farm.fireflyserver.common.response.BaseResponse;
+import org.farm.fireflyserver.common.response.SuccessCode;
+import org.farm.fireflyserver.domain.manager.service.ManagerService;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/manager")
+@RequiredArgsConstructor
+public class ManagerController {
+    private final ManagerService managerService;
+
+    @GetMapping()
+    public BaseResponse<?> getAllManagers() {
+        List<ManagerDto.SimpleInfo> dtos = managerService.getAllManagers();
+
+        return BaseResponse.of(SuccessCode.OK, dtos);
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -23,4 +23,6 @@ public class ManagerController {
 
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
+
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -31,4 +31,11 @@ public class ManagerController {
 
         return BaseResponse.of(SuccessCode.OK, dto);
     }
+
+    @GetMapping("/{id}/seniors")
+    public BaseResponse<?> getSeniorsByManagerId(@PathVariable Long id) {
+        List<ManagerDto.SeniorInfo> dtos = managerService.getSeniorsByManagerId(id);
+
+        return BaseResponse.of(SuccessCode.OK, dtos);
+    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -3,6 +3,7 @@ package org.farm.fireflyserver.domain.manager.web;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
+import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.manager.service.ManagerService;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,6 +36,20 @@ public class ManagerController {
     @GetMapping("/{id}/seniors")
     public BaseResponse<?> getSeniorsByManagerId(@PathVariable Long id) {
         List<ManagerDto.SeniorInfo> dtos = managerService.getSeniorsByManagerId(id);
+
+        return BaseResponse.of(SuccessCode.OK, dtos);
+    }
+
+    @GetMapping("/{id}/call")
+    public BaseResponse<?> getCareCallsByManagerId(@PathVariable Long id) {
+        List<ManagerDto.CareSeniorInfo> dtos = managerService.getCareSeniorInfoByManagerAndCareType(id, Type.CALL);
+
+        return BaseResponse.of(SuccessCode.OK, dtos);
+    }
+
+    @GetMapping("/{id}/visit")
+    public BaseResponse<?> getCareVisitsByManagerId(@PathVariable Long id) {
+        List<ManagerDto.CareSeniorInfo> dtos = managerService.getCareSeniorInfoByManagerAndCareType(id, Type.VISIT);
 
         return BaseResponse.of(SuccessCode.OK, dtos);
     }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.domain.manager.web.dto;
 
+import org.farm.fireflyserver.domain.senior.persistence.entity.Gender;
+
 public class ManagerDto {
 
     public record SimpleInfo(
@@ -16,6 +18,14 @@ public class ManagerDto {
             String phone,
             String affiliation,
             String email,
+            String address
+    ){}
+
+    public record SeniorInfo(
+            Long seniorId,
+            String name,
+            Gender gender,
+            Long age,
             String address
     ){}
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -9,4 +9,13 @@ public class ManagerDto {
             String careCnt,
             String recentCareDate
     ){}
+
+    public record DetailInfo(
+            Long managerId,
+            String name,
+            String phone,
+            String affiliation,
+            String email,
+            String address
+    ){}
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -1,0 +1,11 @@
+package org.farm.fireflyserver.domain.manager.web.dto;
+
+public class ManagerDto {
+
+    public record SimpleInfo(
+            String name,
+            String seniorCnt,
+            String careCnt,
+            String recentCareDate
+    ){}
+}

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -1,6 +1,9 @@
 package org.farm.fireflyserver.domain.manager.web.dto;
 
+import org.farm.fireflyserver.domain.care.persistence.entity.Result;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Gender;
+
+import java.time.LocalDateTime;
 
 public class ManagerDto {
 
@@ -27,5 +30,13 @@ public class ManagerDto {
             Gender gender,
             Long age,
             String address
+    ){}
+
+    public record CareSeniorInfo(
+            String seniorName,
+            Gender seniorGender,
+            Long seniorAge,
+            LocalDateTime careDate,
+            Result careResult
     ){}
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -3,6 +3,7 @@ package org.farm.fireflyserver.domain.manager.web.dto;
 public class ManagerDto {
 
     public record SimpleInfo(
+            Long managerId,
             String name,
             String seniorCnt,
             String careCnt,

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerDto.java
@@ -3,22 +3,23 @@ package org.farm.fireflyserver.domain.manager.web.dto;
 import org.farm.fireflyserver.domain.care.persistence.entity.Result;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Gender;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class ManagerDto {
 
     public record SimpleInfo(
             Long managerId,
             String name,
-            String seniorCnt,
-            String careCnt,
-            String recentCareDate
+            Long seniorCnt,
+            Long careCnt,
+            LocalDate recentCareDate
     ){}
 
     public record DetailInfo(
             Long managerId,
             String name,
             String phone,
+            LocalDate birth,
             String affiliation,
             String email,
             String address
@@ -36,7 +37,7 @@ public class ManagerDto {
             String seniorName,
             Gender seniorGender,
             Long seniorAge,
-            LocalDateTime careDate,
+            String careDate,
             Result careResult
     ){}
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/service/SeniorService.java
@@ -1,5 +1,6 @@
 package org.farm.fireflyserver.domain.senior.service;
 
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.farm.fireflyserver.domain.senior.web.dto.request.RegisterSeniorDto;
 import org.farm.fireflyserver.domain.senior.web.dto.request.RequestSeniorDto;
 import org.farm.fireflyserver.domain.senior.web.dto.response.SeniorDetailDto;
@@ -16,4 +17,6 @@ public interface SeniorService {
     SeniorDetailDto getSeniorDetail(Long seniorId);
 
     void deactivateSenior(RequestSeniorDto.Deactivate dto);
+
+    List<ManagerDto.SeniorInfo> getSeniorInfoByIds(List<Long> seniorIds);
 }

--- a/src/main/java/org/farm/fireflyserver/domain/senior/service/SeniorServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/senior/service/SeniorServiceImpl.java
@@ -6,6 +6,7 @@ import org.farm.fireflyserver.common.response.ErrorCode;
 import org.farm.fireflyserver.domain.account.persistence.entity.Account;
 import org.farm.fireflyserver.domain.care.persistence.entity.Care;
 import org.farm.fireflyserver.domain.led.web.dto.response.LedStateDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.farm.fireflyserver.domain.senior.persistence.entity.SeniorStatus;
 import org.farm.fireflyserver.domain.senior.web.dto.request.RequestSeniorDto;
 import org.farm.fireflyserver.domain.senior.web.dto.response.SeniorDetailDto;
@@ -18,6 +19,8 @@ import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorReposit
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -133,5 +136,19 @@ public class SeniorServiceImpl implements SeniorService {
         return latestCare.getManagerAccount();
     }
 
-
+    @Override
+    public List<ManagerDto.SeniorInfo> getSeniorInfoByIds(List<Long> seniorIds) {
+        return seniorRepository.findAllById(seniorIds).stream()
+                .map(senior -> {
+                    long age = Period.between(senior.getBirthday(), LocalDate.now()).getYears();
+                    return new ManagerDto.SeniorInfo(
+                            senior.getSeniorId(),
+                            senior.getName(),
+                            senior.getGender(),
+                            age,
+                            senior.getAddress()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close : #36
 
## 💡 작업 사항
- 담당자 페이지의 API를 구현하였습니다.
- querydsl을 도입하였습니다.
- 새로운 Manager 테이블을 추가했습니다.
- Care와 Manager 테이블 연관관계를 추가했습니다(manager_id).
- Care 테이블에서 기존에 Account와의 외래키인 manager_id를 manager_account_id로 변경했습니다.
   -> 기존에 Account와 Care와의 연관관계가 필요없다고 생각되기 때문에, 추후 제거할 필요성이 있습니다.
- Manager 테이블에 돌봄 건수, 대상자 수 컬럼이 생겼기 때문에 대상자 혹은 돌봄 등록 시 해당 열을 업데이트하는 로직이 추가되어야 합니다.

## 💡 참고 사항
의존성이 추가되어서 gradle 빌드 다시 하시고 작업하시면 됩니다!
