### PR TITLE
fix : Led History와 현재상태 저장 테이블 분리 

### DIFF
--- a/src/main/java/org/farm/fireflyserver/common/config/SecurityConfig.java
+++ b/src/main/java/org/farm/fireflyserver/common/config/SecurityConfig.java
@@ -31,12 +31,13 @@ public class SecurityConfig {
             "v3/api-docs/**",
 
             /* api */
+            //TODO : 보안상 토큰 필요하면 화이트 리스트에서 제거
             "/token/**",
             "/senior/**",
             "/led/save",
             "/account/login",
-            "/monitoring/**"
-
+            "/monitoring/**",
+            "/manager/**"
             };
 
     @Bean

--- a/src/main/java/org/farm/fireflyserver/common/util/BaseUpdatedTimeEntity.java
+++ b/src/main/java/org/farm/fireflyserver/common/util/BaseUpdatedTimeEntity.java
@@ -14,4 +14,7 @@ public abstract class BaseUpdatedTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public void updateTime(LocalDateTime updatedTime) {
+        this.updatedAt = updatedTime;
+    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/account/service/AccountServiceImpl.java
@@ -37,7 +37,7 @@ public class AccountServiceImpl implements AccountService {
             throw new EntityNotFoundException(PASSWORD_NOT_FOUND);
         }
 
-        return new TokenDto(getAccessToken(account));
+        return new TokenDto(getAccessToken(account), account.getName());
 
     }
 

--- a/src/main/java/org/farm/fireflyserver/domain/account/web/dto/TokenDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/account/web/dto/TokenDto.java
@@ -1,6 +1,7 @@
 package org.farm.fireflyserver.domain.account.web.dto;
 
 public record TokenDto(
-        String accessToken
+        String accessToken,
+        String accountName
 ) {
 }

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/entity/Care.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/entity/Care.java
@@ -23,6 +23,7 @@ public class Care extends BaseCreatedTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long careId;
 
+    // TODO : 연결된 부분 정리하고 이후 연결 끊기
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_account_id")
     @Comment("돌봄 담당자 계정")

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedData.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedData.java
@@ -20,7 +20,9 @@ public class LedData {
     @Column(name = "SNSR_SN")
     private String snsrSn;
 
+    /*
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "led_state_id")
     private LedState ledState;
+    */
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedHistory.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedHistory.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @Table(name = "led_history")
-public class LedHistory extends BaseCreatedTimeEntity {
+public class LedHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,8 +32,4 @@ public class LedHistory extends BaseCreatedTimeEntity {
 
     @Comment("LED ON/OFF 시각")
     private LocalDateTime eventTime;
-
-    public void updateEventTime(LocalDateTime eventTime) {
-        this.eventTime = eventTime;
-    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedState.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/entity/LedState.java
@@ -1,16 +1,21 @@
 package org.farm.fireflyserver.domain.led.persistence.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.farm.fireflyserver.common.util.BaseUpdatedTimeEntity;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.hibernate.annotations.Comment;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @Table(name="led_state")
 public class LedState extends BaseUpdatedTimeEntity {
 
@@ -18,15 +23,28 @@ public class LedState extends BaseUpdatedTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long ledStateId;
 
-    @Comment("LED ON/OFF 정보")
-    private boolean isOn;
+    @Comment("LED 식별 번호")
+    private String ledMtchnSn;
 
     @Enumerated(EnumType.STRING)
     @Comment("LED 센서 구분")
     private SensorGbn sensorGbn;
 
+    @Comment("LED ON/OFF 정보")
+    @Enumerated(EnumType.STRING)
+    private OnOff onOff;
+
     @ManyToOne
     @JoinColumn(name = "senior_id", nullable = false)
     @Comment("대상자 식별 정보")
     private Senior senior;
+
+    public void updateState(OnOff onOff) {
+        this.onOff = onOff;
+    }
+
+    public void updateTime(LocalDateTime updatedTime) {
+        super.updateTime(updatedTime);
+    }
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedHistoryRepository.java
@@ -16,20 +16,14 @@ public interface LedHistoryRepository extends JpaRepository<LedHistory, Long> {
     boolean existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
             String ledMtchnSn, SensorGbn sensorGbn, OnOff onOff, LocalDateTime eventTime);
 
-    // 특정 LED센서 최신 데이터 조회
-    LedHistory findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDescLedHistoryIdDesc(String ledMtchnSn, SensorGbn sensorGbn);
-
     // 모든 LED센서 최신 데이터 조회
-    //JPQL에서 일부 기능 사용 불가하여 NativeQuery 사용
-    @Query(value = """
-    SELECT l.*
-    FROM led_history l
-    JOIN (
-        SELECT t.led_mtchn_sn, t.sensor_gbn, MAX(t.led_history_id) AS max_id
-        FROM led_history t
-        GROUP BY t.led_mtchn_sn, t.sensor_gbn
-    ) latest
-      ON l.led_history_id = latest.max_id
-    """, nativeQuery = true)
+    @Query("""
+    SELECT l FROM LedHistory l
+    WHERE l.ledHistoryId IN (
+        SELECT MAX(l2.ledHistoryId)
+        FROM LedHistory l2
+        GROUP BY l2.ledMtchnSn, l2.sensorGbn
+    )
+    """)
     List<LedHistory> findLatestHistories();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedStateRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/persistence/repository/LedStateRepository.java
@@ -1,0 +1,13 @@
+package org.farm.fireflyserver.domain.led.persistence.repository;
+
+import org.farm.fireflyserver.domain.led.persistence.entity.LedState;
+import org.farm.fireflyserver.domain.led.persistence.entity.SensorGbn;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LedStateRepository extends JpaRepository<LedState, Long> {
+
+    Optional<LedState> findByLedMtchnSnAndSensorGbn(String ledMtchnSn, SensorGbn sensorGbn);
+
+}

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemWriter.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedItemWriter.java
@@ -2,10 +2,13 @@ package org.farm.fireflyserver.domain.led.service.batch;
 
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.domain.led.persistence.entity.LedHistory;
+import org.farm.fireflyserver.domain.led.persistence.entity.LedState;
 import org.farm.fireflyserver.domain.led.persistence.entity.OnOff;
 import org.farm.fireflyserver.domain.led.persistence.entity.SensorGbn;
 import org.farm.fireflyserver.domain.led.persistence.repository.LedHistoryRepository;
+import org.farm.fireflyserver.domain.led.persistence.repository.LedStateRepository;
 import org.farm.fireflyserver.domain.led.web.dto.response.LedDataLogDto;
+import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 
@@ -20,98 +23,103 @@ import java.util.List;
 public class LedItemWriter implements ItemWriter<Map<String, LedDataLogDto>> {
 
     private final LedHistoryRepository ledHistoryRepository;
+    private final LedStateRepository ledStateRepository;
+
     private final Map<String, LocalDateTime> windowTimes;
     private final Map<String, LocalDateTime> lastWritten = new HashMap<>();
 
     @Override
-    public void write(Chunk<? extends Map<String, LedDataLogDto>> chunk ) {
-
-        Map<String, LedDataLogDto> latestMap = new HashMap<>();
-
+    public void write(Chunk<? extends Map<String, LedDataLogDto>> chunk) {
         final LocalDateTime start = windowTimes.get("windowStart");
         final LocalDateTime now = windowTimes.get("now");
 
-        // 청크 단위로 Processor에서 온 최신 ON 로그 병합
+        // 청크 단위로 Processor에서 온 최신 ON 로그 가장 최근 1건으로 병합
+        Map<String, LedDataLogDto> latestMap = new HashMap<>();
         for (Map<String, LedDataLogDto> map : chunk) {
-            for (Map.Entry<String, LedDataLogDto> entry : map.entrySet()) {
-                String key = entry.getKey();
-                LedDataLogDto dto = entry.getValue();
+            for (Map.Entry<String, LedDataLogDto> e : map.entrySet()) {
+                LedDataLogDto dto = e.getValue();
+                if (dto.eventTime().isBefore(start) || !dto.eventTime().isBefore(now)) continue; // 윈도우 검증
 
-                //임시 : 시간 재검증용
-                if (dto.eventTime().isBefore(start) || !dto.eventTime().isBefore(now)) {
-                    continue;
-                }
-
-                LedDataLogDto existing = latestMap.get(key);
-                if (existing == null || existing.eventTime().isBefore(dto.eventTime())) {
-                    latestMap.put(key, dto);
-                }
+                latestMap.merge(
+                        e.getKey(),
+                        dto,
+                        (oldV, newV) -> oldV.eventTime().isBefore(newV.eventTime()) ? newV : oldV
+                );
             }
         }
 
-        // ON 이벤트 처리 결과 저장용
         List<LedHistory> toSave = getSaveList(latestMap);
-
         if (!toSave.isEmpty()) {
             ledHistoryRepository.saveAll(toSave);
         }
     }
 
+
     private List<LedHistory> getSaveList(Map<String, LedDataLogDto> latestMap) {
         List<LedHistory> toSave = new ArrayList<>();
 
-        for (Map.Entry<String, LedDataLogDto> entry : latestMap.entrySet()) {
-            String key = entry.getKey();
-            LedDataLogDto dto = entry.getValue();
+        for (Map.Entry<String, LedDataLogDto> e : latestMap.entrySet()) {
+            String key = e.getKey();
+            LedDataLogDto dto = e.getValue();
 
             LocalDateTime prev = lastWritten.get(key);
-            if (prev != null && !dto.eventTime().isAfter(prev)) {
-                continue;
-            }
+            if (prev != null && !dto.eventTime().isAfter(prev)) continue; // 중복 방지
 
             String[] parts = key.split("_", 2);
             String ledMtchnSn = parts[0];
             SensorGbn sensorGbn = SensorGbn.fromCode(parts[1]);
 
-            LedHistory candidate = decideUpsert(ledMtchnSn, sensorGbn, dto);
+            LedHistory candidate = upsertStateAndHistory(ledMtchnSn, sensorGbn, dto);
             if (candidate != null) {
                 toSave.add(candidate);
                 lastWritten.put(key, dto.eventTime());
             }
         }
-
         return toSave;
     }
 
+    // LedState 생성/갱신 + LedHistory 생성 결정 함수
+    private LedHistory upsertStateAndHistory(String ledMtchnSn, SensorGbn sensorGbn, LedDataLogDto dto) {
+        final LocalDateTime now = windowTimes.get("now");
+        LedHistory historyToSave = null;
 
-    private LedHistory decideUpsert(String ledMtchnSn, SensorGbn sensorGbn, LedDataLogDto dto) {
-        // 해당 LED센서의 최신 히스토리 조회
-        LedHistory latestHistory = ledHistoryRepository
-                .findTopByLedMtchnSnAndSensorGbnOrderByEventTimeDescLedHistoryIdDesc(ledMtchnSn, sensorGbn);
+        // 현재 상태 조회
+        LedState state = ledStateRepository
+                .findByLedMtchnSnAndSensorGbn(ledMtchnSn, sensorGbn)
+                .orElse(null);
 
-        // CASE 1: DB 없음 → Processor 있음 → ON 이벤트 추가
-        if (latestHistory == null) {
+        //CASE 1 : 상태 없음 → 새로 생성(ON) + 최초 ON 히스토리 기록
+        if (state == null) {
+            state = LedState.builder()
+                    .ledMtchnSn(ledMtchnSn)
+                    .sensorGbn(sensorGbn)
+                    .onOff(OnOff.ON)
+                    .senior(Senior.builder().seniorId(1L).build()) // TODO: 임시 매핑. 실제 senior 매핑으로 수정
+                    .build();
+            ledStateRepository.save(state);
+
+            // LedHistory 기록
             if (!ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
                     ledMtchnSn, sensorGbn, OnOff.ON, dto.eventTime())) {
-                return dto.toLedHistory(OnOff.ON);
+                historyToSave = dto.toLedHistory(OnOff.ON);
             }
-            return null;
         }
-        // CASE 2: DB 있음(OFF) → Processor 있음 → ON 이벤트 추가
-        else if (latestHistory.getOnOff() == OnOff.OFF) {
-            if (!ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
-                    ledMtchnSn, sensorGbn, OnOff.ON, dto.eventTime())) {
-                return dto.toLedHistory(OnOff.ON);
+        //CASE 2 : LedState=OFF → ON으로 전환 + ON 히스토리 기록
+        else if (state.getOnOff() == null || state.getOnOff() == OnOff.OFF) {
+            boolean exists = ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
+                    ledMtchnSn, sensorGbn, OnOff.ON, dto.eventTime());
+            if (!exists) {
+                state.updateState(OnOff.ON);
+                ledStateRepository.save(state);
+                historyToSave = dto.toLedHistory(OnOff.ON);
             }
-            return null;
         }
-        // CASE 3: DB 있음(ON) → Processor 있음 → eventTime 시간 업데이트
-        else if (latestHistory.getOnOff() == OnOff.ON &&
-                !latestHistory.getEventTime().isEqual(dto.eventTime())) {
-            latestHistory.updateEventTime(dto.eventTime());
-            return latestHistory;
+        //CASE 3 : LedState=ON → 상태는 유지하되 updatedAt만 갱신 (히스토리 추가 없음)
+        else {
+            state.updateTime(now);
+            ledStateRepository.save(state);
         }
 
-        return null;
+        return historyToSave;
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedJobListener.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/service/batch/LedJobListener.java
@@ -1,72 +1,85 @@
 package org.farm.fireflyserver.domain.led.service.batch;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.farm.fireflyserver.domain.led.persistence.entity.LedHistory;
+import org.farm.fireflyserver.domain.led.persistence.entity.LedState;
 import org.farm.fireflyserver.domain.led.persistence.entity.OnOff;
 import org.farm.fireflyserver.domain.led.persistence.repository.LedHistoryRepository;
+import org.farm.fireflyserver.domain.led.persistence.repository.LedStateRepository;
 import org.farm.fireflyserver.domain.led.web.dto.response.LedDataLogDto;
+import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.listener.JobExecutionListenerSupport;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-// Job 종료 후, 최신 ON 이벤트가 Processor에 없으면 OFF 이벤트 추가
+// Job 종료 후 실행
+// CASE4 : 센서별 최신 히스토리가 ON인데, Processor에 없는 경우 → OFF 히스토리 기록 + 현재 상태를 OFF로 전환
 @RequiredArgsConstructor
-@Slf4j
 public class LedJobListener extends JobExecutionListenerSupport {
 
     private final LedHistoryRepository ledHistoryRepository;
+    private final LedStateRepository ledStateRepository;
     private final Map<String, LedDataLogDto> latestMap;
     private final Map<String, LocalDateTime> windowTimes;
 
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    // CASE 4: DB 있음(ON) → Processor 없음 → OFF 이벤트 추가
     @Override
     public void afterJob(JobExecution jobExecution) {
-
         final LocalDateTime now = windowTimes.get("now");
+        final Set<String> observed = latestMap.keySet();
 
-        entityManager.clear();  // 캐시 초기화
+        List<LedHistory> latestPerSensor = ledHistoryRepository.findLatestHistories();
+        List<LedHistory> offHistories = new ArrayList<>();
+        List<LedState> statesToSave = new ArrayList<>();
 
-        // 모든 LED센서 최신 데이터 조회
-        List<LedHistory> allHistories = ledHistoryRepository.findLatestHistories();
-
-        //로그
-        allHistories.forEach(h ->
-                log.info("[Listener] latest id={}, sn={}, gbn={}, onOff={}, eventTime={}",
-                        h.getLedHistoryId(), h.getLedMtchnSn(), h.getSensorGbn(),
-                        h.getOnOff(), h.getEventTime())
-        );
-
-        for (LedHistory history : allHistories) {
-            String key = history.getLedMtchnSn() + "_" + history.getSensorGbn().getCode();
-
-            // 스킵
-            if (history.getOnOff() != OnOff.ON || latestMap.containsKey(key)) {
+        for (LedHistory latest : latestPerSensor) {
+            // 최신 상태가 ON이 아니거나, 이번 윈도우에서 관측된 경우는 스킵
+            if (latest.getOnOff() != OnOff.ON) {
+                continue;
+            }
+            String key = latest.getLedMtchnSn() + "_" + latest.getSensorGbn().getCode();
+            if (observed.contains(key)) {
                 continue;
             }
 
-            boolean offExists = ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(
-                    history.getLedMtchnSn(), history.getSensorGbn(), OnOff.OFF, now);
-            if (offExists) {
-                continue;
+            // OFF 히스토리 추가
+            boolean alreadyOff = ledHistoryRepository.existsByLedMtchnSnAndSensorGbnAndOnOffAndEventTime(latest.getLedMtchnSn(), latest.getSensorGbn(), OnOff.OFF, now
+            );
+            if (!alreadyOff) {
+                offHistories.add(
+                        LedHistory.builder()
+                                .ledMtchnSn(latest.getLedMtchnSn())
+                                .sensorGbn(latest.getSensorGbn())
+                                .onOff(OnOff.OFF)
+                                .eventTime(now)
+                                .build()
+                );
             }
 
-            // OFF 이벤트 추가
-            LedHistory offHistory = LedHistory.builder()
-                    .ledMtchnSn(history.getLedMtchnSn())
-                    .sensorGbn(history.getSensorGbn())
-                    .onOff(OnOff.OFF)
-                    .eventTime(now)
-                    .build();
-            ledHistoryRepository.save(offHistory);
+            // LED 현재 상태 업데이트
+            LedState state = ledStateRepository.findByLedMtchnSnAndSensorGbn(latest.getLedMtchnSn(), latest.getSensorGbn())
+                    .orElseGet(() ->
+                            LedState.builder()
+                                    .ledMtchnSn(latest.getLedMtchnSn())
+                                    .sensorGbn(latest.getSensorGbn())
+                                    .onOff(OnOff.OFF)
+                                    .senior(Senior.builder().seniorId(1L).build()) // TODO: Senior 매핑 추가
+                                    .build()
+                    );
+
+            if (state.getOnOff() != OnOff.OFF) {
+                state.updateState(OnOff.OFF);
+            }
+            statesToSave.add(state);
         }
+
+        if (!offHistories.isEmpty()) ledHistoryRepository.saveAll(offHistories);
+        if (!statesToSave.isEmpty()) ledStateRepository.saveAll(statesToSave);
+
     }
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/web/dto/request/SaveLedDataDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/web/dto/request/SaveLedDataDto.java
@@ -13,7 +13,6 @@ public record SaveLedDataDto(
         return LedData.builder()
                 .trgSn(dto.trgSn())
                 .snsrSn(dto.snsrSn())
-                .ledState(null)
                 .build();
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/led/web/dto/response/LedStateDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/led/web/dto/response/LedStateDto.java
@@ -1,6 +1,7 @@
 package org.farm.fireflyserver.domain.led.web.dto.response;
 
 import org.farm.fireflyserver.domain.led.persistence.entity.LedState;
+import org.farm.fireflyserver.domain.led.persistence.entity.OnOff;
 
 public record LedStateDto(
         String sensorGbn,
@@ -10,7 +11,7 @@ public record LedStateDto(
     public static LedStateDto of(LedState ledState) {
         return new LedStateDto(
                 ledState.getSensorGbn().getDesc(),
-                ledState.isOn()
+                ledState.getOnOff() == OnOff.ON
         );
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/ManagerRepository.java
@@ -3,5 +3,8 @@ package org.farm.fireflyserver.domain.manager.persistence;
 import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ManagerRepository extends JpaRepository<Manager, Long>, ManagerRepositoryCustom {
+    List<Manager> findAllByOrderByNameAsc();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.farm.fireflyserver.domain.account.persistence.entity.Account;
 import org.farm.fireflyserver.domain.care.persistence.entity.Care;
 import org.hibernate.annotations.Comment;
 
@@ -58,4 +59,8 @@ public class Manager {
 
     @OneToMany(mappedBy = "manager")
     private List<Care> careList = new ArrayList<>();
+
+    @OneToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerService.java
@@ -2,6 +2,7 @@ package org.farm.fireflyserver.domain.manager.service;
 
 import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerNameDto;
 
 import java.util.List;
 
@@ -10,4 +11,6 @@ public interface ManagerService {
     ManagerDto.DetailInfo getManagerById(Long id);
     List<ManagerDto.SeniorInfo> getSeniorsByManagerId(Long id);
     List<ManagerDto.CareSeniorInfo> getCareSeniorInfoByManagerAndCareType(Long managerId, Type careType);
+
+    List<ManagerNameDto> getManagerNameList();
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/service/ManagerServiceImpl.java
@@ -6,7 +6,9 @@ import org.farm.fireflyserver.common.response.ErrorCode;
 import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.care.service.CareService;
 import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
+import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerNameDto;
 import org.farm.fireflyserver.domain.senior.service.SeniorService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,5 +53,11 @@ public class ManagerServiceImpl implements ManagerService {
         }
 
         return careService.getCareSeniorInfoByManagerAndCareType(managerId, careType);
+    }
+
+    @Override
+    public List<ManagerNameDto> getManagerNameList () {
+        List<Manager> managerList = managerRepository.findAllByOrderByNameAsc();
+        return managerList.stream().map(ManagerNameDto::from).toList();
     }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -6,6 +6,7 @@ import org.farm.fireflyserver.common.response.SuccessCode;
 import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.manager.service.ManagerService;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
+import org.farm.fireflyserver.domain.manager.web.dto.ManagerNameDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,4 +54,12 @@ public class ManagerController {
 
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
+
+    //담당자 {이름,전화번호} 리스트
+    @GetMapping("/name")
+    public BaseResponse<?> getManagerNames() {
+        List<ManagerNameDto> managerNameList = managerService.getManagerNameList();
+        return BaseResponse.of(SuccessCode.OK, managerNameList);
+    }
+
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -1,5 +1,7 @@
 package org.farm.fireflyserver.domain.manager.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -17,6 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/manager")
 @RequiredArgsConstructor
+@Tag(name = "Manager", description = "돌봄 담당자 관련 API")
 public class ManagerController {
     private final ManagerService managerService;
 
@@ -55,7 +58,8 @@ public class ManagerController {
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
 
-    //담당자 {이름,전화번호} 리스트
+    //담당자 {이름,전화번호} 리스트 조회
+    @Operation(summary = "대상자 등록시 돌봄 담당자 {이름,전화번호} 리스트 조회", description = "대상자 등록시 `1.돌봄 담당자 이름 리스트 조회` -> `2.해당 이름 클릭시 전화번호 조회`에 사용")
     @GetMapping("/name")
     public BaseResponse<?> getManagerNames() {
         List<ManagerNameDto> managerNameList = managerService.getManagerNameList();

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerNameDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/dto/ManagerNameDto.java
@@ -1,0 +1,15 @@
+package org.farm.fireflyserver.domain.manager.web.dto;
+
+import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
+
+public record ManagerNameDto(
+        String managerName,
+        String phoneNumber
+) {
+    public static ManagerNameDto from(Manager manager) {
+        return new ManagerNameDto(
+                manager.getName(),
+                manager.getPhoneNum()
+        );
+    }
+}

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/service/MonitoringServiceImpl.java
@@ -12,10 +12,7 @@ import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorReposit
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -86,7 +83,6 @@ public class MonitoringServiceImpl implements MonitoringService {
         for (Object[] row : results) {
             DangerLevel level = (DangerLevel) row[0];
             int count = ((Long) row[1]).intValue();
-
             if (level == null) level = DangerLevel.NORMAL;
 
             switch (level) {
@@ -99,7 +95,17 @@ public class MonitoringServiceImpl implements MonitoringService {
 
         int ledUseCount = seniorRepository.countByIsActiveTrueAndIsLedUseTrue();
 
-        return SeniorLedStateCountDto.of(ledUseCount, normalCount, attentionCount, cautionCount, dangerCount);
+        LocalTime recentUpdateTime = getRecentUpdateTime();
+
+        return SeniorLedStateCountDto.of(recentUpdateTime, ledUseCount, normalCount, attentionCount, cautionCount, dangerCount);
+    }
+
+    //최근 업데이트 시간
+    private LocalTime getRecentUpdateTime() {
+        LocalTime now = LocalTime.now();
+        //업데이트 단위(5분) 기준 가장 가까운 시간
+        int minute = now.getMinute()/5*5;
+        return LocalTime.of(now.getHour(), minute);
     }
 
     // 담당자 현황

--- a/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateCountDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/monitoring/web/dto/SeniorLedStateCountDto.java
@@ -1,6 +1,9 @@
 package org.farm.fireflyserver.domain.monitoring.web.dto;
 
+import java.time.LocalTime;
+
 public record SeniorLedStateCountDto(
+        LocalTime recentUpdateTime,
         int ledUseCount,
         //정상
         int normalCount,
@@ -12,9 +15,10 @@ public record SeniorLedStateCountDto(
         int dangerCount
 
 ) {
-    public static SeniorLedStateCountDto of(int ledUseCount, int normalCount, int interestCount, int cautionCount, int dangerCount
+    public static SeniorLedStateCountDto of(LocalTime recentUpdateTime, int ledUseCount, int normalCount, int interestCount, int cautionCount, int dangerCount
     ) {
         return new SeniorLedStateCountDto(
+                recentUpdateTime,
                 ledUseCount,
                 normalCount,
                 interestCount,


### PR DESCRIPTION
## 💡 관련 이슈
 
## 💡 작업 사항

- 로그인 API 수정사항 반영
- 담당자 등록시 리스트 조회 반환 API 구현
- 배치 수정 사항 반영 : Led History와 현재상태 저장 테이블 분리

<전체적인 흐름>
1 ) Reader: 실행 시각 기준 최근 10분 이내의 LED 센서 로그 조회
2) Processor: 센서별 최신 로그 1건만 남김
3) Writer: LedState(현재 상태)에 따라
                    - OFF → ON : LedHistory에 ON 이벤트 추가 + LedState를 ON으로 전환
                    - ON 유지 시: LedState의 updatedAt만 갱신 (히스토리 추가 없음)
4) Listener : 직전 상태가 ON인데 이번 윈도우에 로그가 없으면 LedHistory에 OFF 이벤트 추가 + LedState를 OFF로 전환

=> 쉽게 말해 Led State에 현재 상태가, Led History에는 On/Off시간이 저장되는 흐름이라고 생각하면 됩니다. 


<img width="766" height="172" alt="스크린샷 2025-09-20 16 51 15" src="https://github.com/user-attachments/assets/9770960d-35b2-424d-967a-87a4a92e7301" />

`led_state테이블`


<img width="692" height="168" alt="스크린샷 2025-09-20 16 50 59" src="https://github.com/user-attachments/assets/f3a7fc71-e6bf-44e0-89ea-6d2782190ca0" />

`led_history테이블`

## 💡 참고 사항
- 시간 관련해서 +-10분정도의 오차는 있을 수 있습니다 ((시간 저장하는 시점 관련한 고민이 필요한 부분인데 다듬어야함!
- 기존 저장하던 led_histoty테이블명은 led_history2로 변경하였습니다.
- Senior와 Led 식별자 매핑은 임시 고정 매핑해놔서 수정해야합니다.

