### PR TITLE
돌봄 등록 시 manager 테이블 업데이트

### DIFF
--- a/src/main/java/org/farm/fireflyserver/common/response/ErrorCode.java
+++ b/src/main/java/org/farm/fireflyserver/common/response/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     SENIOR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시니어를 찾을 수 없습니다."),
     ACCOUNT_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 계정 아이디를 찾을 수 없습니다."),
     PASSWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 비밀번호를 찾을 수 없습니다."),
+    MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 매니저를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/persistence/CareRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface CareRepository extends JpaRepository<Care, Long>, CareRepositoryCustom {
     @Query("SELECT c FROM Care c " +
-            "LEFT JOIN c.managerAccount m " +
+            "LEFT JOIN c.manager m " +
             "LEFT JOIN c.senior s WHERE " +
             "(:#{#req.type} IS NULL OR c.type = :#{#req.type}) AND " +
             "(:#{#req.result} IS NULL OR c.result = :#{#req.result}) AND " +

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
@@ -4,8 +4,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.exception.EntityNotFoundException;
 import org.farm.fireflyserver.common.response.ErrorCode;
-import org.farm.fireflyserver.domain.account.persistence.AccountRepository;
-import org.farm.fireflyserver.domain.account.persistence.entity.Account;
 import org.farm.fireflyserver.domain.care.persistence.entity.Result;
 import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.care.mapper.CareMapper;
@@ -18,6 +16,8 @@ import org.farm.fireflyserver.domain.care.persistence.entity.CareResult;
 import org.farm.fireflyserver.domain.care.web.dto.AbsentCareDetailsDto;
 import org.farm.fireflyserver.domain.care.web.dto.CareDto;
 import org.farm.fireflyserver.domain.care.web.dto.NormalCareDetailsDto;
+import org.farm.fireflyserver.domain.manager.persistence.ManagerRepository;
+import org.farm.fireflyserver.domain.manager.persistence.entity.Manager;
 import org.farm.fireflyserver.domain.manager.web.dto.ManagerDto;
 import org.farm.fireflyserver.domain.senior.persistence.entity.Senior;
 import org.farm.fireflyserver.domain.senior.persistence.repository.SeniorRepository;
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CareServiceImpl implements CareService {
     private final CareRepository careRepository;
-    private final AccountRepository accountRepository;
+    private final ManagerRepository managerRepository;
     private final SeniorRepository seniorRepository;
     private final CareResultRepository careResultRepository;
     private final AbsentResultRepository absentResultRepository;
@@ -41,10 +41,12 @@ public class CareServiceImpl implements CareService {
 
     @Override
     public void addCare(CareDto.Register dto) {
-        Account manager = accountRepository.findById(dto.getManager_id())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        Manager manager = managerRepository.findById(dto.getManager_id())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MANAGER_NOT_FOUND));
         Senior senior = seniorRepository.findById(dto.getSenior_id())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SENIOR_NOT_FOUND));
+
+        manager.addCare();
 
         Result result;
         if ("COMPLETED".equalsIgnoreCase(dto.getResult())) {
@@ -57,7 +59,7 @@ public class CareServiceImpl implements CareService {
 
         Care care = Care.builder()
                 .content(dto.getContent())
-                .managerAccount(manager)
+                .manager(manager)
                 .result(result)
                 .senior(senior)
                 .type(type)

--- a/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/service/CareServiceImpl.java
@@ -46,8 +46,6 @@ public class CareServiceImpl implements CareService {
         Senior senior = seniorRepository.findById(dto.getSenior_id())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SENIOR_NOT_FOUND));
 
-        manager.addCare();
-
         Result result;
         if ("COMPLETED".equalsIgnoreCase(dto.getResult())) {
             result = Result.NORMAL;
@@ -66,6 +64,9 @@ public class CareServiceImpl implements CareService {
                 .build();
 
         careRepository.save(care);
+
+        //돌봄이 등록 된 후 manager 테이블을 업데이트합니다.
+        manager.addCare();
 
         if (dto.getDetails() instanceof NormalCareDetailsDto details) {
             CareResult careResult = careMapper.toCareResult(details, care);

--- a/src/main/java/org/farm/fireflyserver/domain/care/web/CareController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/web/CareController.java
@@ -1,5 +1,8 @@
 package org.farm.fireflyserver.domain.care.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
 import org.farm.fireflyserver.common.response.SuccessCode;
@@ -10,12 +13,14 @@ import org.springframework.web.bind.annotation.*;
 import java.time.YearMonth;
 import java.util.List;
 
+@Tag(name = "Care", description = "돌봄 관련 api")
 @RestController
 @RequestMapping("/care")
 @RequiredArgsConstructor
 public class CareController {
     private final CareService service;
 
+    @Operation(summary = "돌봄 현황 페이지(리스트형) - 전체 돌봄 현황 조회", description = "전체 돌봄 정보를 조회합니다.")
     @GetMapping()
     public BaseResponse<?> getAllCare() {
         List<CareDto.Response> dto = service.getAllCare();
@@ -23,6 +28,7 @@ public class CareController {
         return BaseResponse.of(SuccessCode.OK, dto);
     }
 
+    @Operation(summary = "돌봄 정보 페이지 - 돌봄 추가", description = "새로운 돌봄 정보를 추가합니다.")
     @PostMapping("/add")
     public BaseResponse<?> addCare(@RequestBody CareDto.Register dto) {
         service.addCare(dto);
@@ -30,6 +36,7 @@ public class CareController {
         return BaseResponse.of(SuccessCode.OK);
     }
 
+    @Operation(summary = "돌봄 현황 페이지(리스트형) - 돌봄 검색", description = "조건에 맞는 돌봄 정보를 검색합니다.")
     @GetMapping("/search")
     public BaseResponse<?> searchCare(@ModelAttribute CareDto.SearchRequest dto) {
         List<CareDto.Response> response = service.searchCare(dto);
@@ -37,8 +44,9 @@ public class CareController {
         return BaseResponse.of(SuccessCode.OK, response);
     }
 
+    @Operation(summary = "대상자 관리 상세 페이지 - 대상자 월별 돌봄 현황 조회", description = "특정 대상자의 월별 돌봄 현황을 조회합니다.")
     @GetMapping("/senior-monthly-status")
-    public BaseResponse<?> seniorMonthlyStatus(Long seniorId, YearMonth yearMonth) {
+    public BaseResponse<?> seniorMonthlyStatus(@Parameter(description = "대상자 ID") Long seniorId, @Parameter(description = "조회 년월") YearMonth yearMonth) {
         CareDto.MonthlyCare dto = service.getSeniorMonthlyCare(seniorId, yearMonth);
 
         return BaseResponse.of(SuccessCode.OK, dto);

--- a/src/main/java/org/farm/fireflyserver/domain/care/web/dto/CareDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/web/dto/CareDto.java
@@ -74,7 +74,7 @@ public class CareDto {
             Long emergCnt,
             List<CareTuple> cares
     ) {
-        public static record CareTuple (
+        public record CareTuple (
                 LocalDateTime careDate,
                 Type careType,
                 Result result

--- a/src/main/java/org/farm/fireflyserver/domain/care/web/dto/CareDto.java
+++ b/src/main/java/org/farm/fireflyserver/domain/care/web/dto/CareDto.java
@@ -3,6 +3,7 @@ package org.farm.fireflyserver.domain.care.web.dto;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.farm.fireflyserver.domain.care.persistence.entity.Result;
 import org.farm.fireflyserver.domain.care.persistence.entity.Type;
 import org.farm.fireflyserver.domain.care.persistence.entity.Care;
@@ -13,7 +14,8 @@ import java.util.List;
 
 public class CareDto {
     @Getter
-    public class Register {
+    @NoArgsConstructor
+    public static class Register {
         private Long manager_id;
         private Long senior_id;
         private LocalDateTime date;
@@ -35,7 +37,7 @@ public class CareDto {
 
     public record Response (
             LocalDateTime date,
-            String managerId,
+            Long managerId,
             String managerName,
             Type type,
             String content,
@@ -46,8 +48,8 @@ public class CareDto {
         public static Response from(Care care) {
             return new Response(
                     care.getDate(),
-                    care.getManagerAccount().getId(),
-                    care.getManagerAccount().getName(),
+                    care.getManager().getManagerId(),
+                    care.getManager().getName(),
                     care.getType(),
                     care.getContent(),
                     String.valueOf(care.getSenior().getSeniorId()),

--- a/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/persistence/entity/Manager.java
@@ -63,4 +63,10 @@ public class Manager {
     @OneToOne
     @JoinColumn(name = "account_id", nullable = false)
     private Account account;
+
+    //돌봄 등록 시 careCnt 1 증가, recentCareDate 오늘 날짜로 변경
+    public void addCare() {
+        this.careCnt++;
+        this.recentCareDate = LocalDate.now();
+    }
 }

--- a/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
+++ b/src/main/java/org/farm/fireflyserver/domain/manager/web/ManagerController.java
@@ -1,6 +1,7 @@
 package org.farm.fireflyserver.domain.manager.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.farm.fireflyserver.common.response.BaseResponse;
@@ -23,6 +24,7 @@ import java.util.List;
 public class ManagerController {
     private final ManagerService managerService;
 
+    @Operation(summary = "전체 담당자 간략 정보 조회", description = "모든 돌봄 담당자의 간략한 정보를 조회합니다.")
     @GetMapping()
     public BaseResponse<?> getAllManagers() {
         List<ManagerDto.SimpleInfo> dtos = managerService.getAllManagers();
@@ -30,29 +32,33 @@ public class ManagerController {
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
 
+    @Operation(summary = "특정 담당자 상세 정보 조회", description = "ID를 사용하여 특정 돌봄 담당자의 상세 정보를 조회합니다.")
     @GetMapping("/{id}")
-    public BaseResponse<?> getManagerById(@PathVariable Long id) {
+    public BaseResponse<?> getManagerById(@Parameter(description = "담당자 ID") @PathVariable Long id) {
         ManagerDto.DetailInfo dto = managerService.getManagerById(id);
 
         return BaseResponse.of(SuccessCode.OK, dto);
     }
 
+    @Operation(summary = "담당자의 담당 대상자 정보 조회", description = "특정 담당자가 담당하는 모든 대상자의 정보를 조회합니다.")
     @GetMapping("/{id}/seniors")
-    public BaseResponse<?> getSeniorsByManagerId(@PathVariable Long id) {
+    public BaseResponse<?> getSeniorsByManagerId(@Parameter(description = "담당자 ID") @PathVariable Long id) {
         List<ManagerDto.SeniorInfo> dtos = managerService.getSeniorsByManagerId(id);
 
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
 
+    @Operation(summary = "담당자의 안부전화 돌봄 정보 조회", description = "특정 담당자의 안부전화 돌봄 대상자 및 최근 돌봄 일시 정보를 조회합니다.")
     @GetMapping("/{id}/call")
-    public BaseResponse<?> getCareCallsByManagerId(@PathVariable Long id) {
+    public BaseResponse<?> getCareCallsByManagerId(@Parameter(description = "담당자 ID") @PathVariable Long id) {
         List<ManagerDto.CareSeniorInfo> dtos = managerService.getCareSeniorInfoByManagerAndCareType(id, Type.CALL);
 
         return BaseResponse.of(SuccessCode.OK, dtos);
     }
 
+    @Operation(summary = "담당자의 방문 돌봄 정보 조회", description = "특정 담당자의 방문 돌봄 대상자 및 최근 돌봄 일시 정보를 조회합니다.")
     @GetMapping("/{id}/visit")
-    public BaseResponse<?> getCareVisitsByManagerId(@PathVariable Long id) {
+    public BaseResponse<?> getCareVisitsByManagerId(@Parameter(description = "담당자 ID") @PathVariable Long id) {
         List<ManagerDto.CareSeniorInfo> dtos = managerService.getCareSeniorInfoByManagerAndCareType(id, Type.VISIT);
 
         return BaseResponse.of(SuccessCode.OK, dtos);


### PR DESCRIPTION
## 💡 관련 이슈
- close : #48 
 
## 💡 작업 사항
돌봄 등록 시 manager 테이블의 돌봄 횟수와 최근 돌봄 일자 컬럼을 업데이트합니다.

## 💡 참고 사항
- Swagger 명세를 추가
- CareDto에서 Jackson 라이브러리가 JSON 역직렬화에 실패하여 수정
  1. @NoArgsConstructor : Jackson 라이브러리는 빈 인스턴스가 있어야 객체를 생성할 수 있다 합니다.
  2. static 선언 : 외부 클래스 인스턴스 없이 중첩 클래스를 인스턴스화하지 못해 static 선언